### PR TITLE
2.6.2 - Fixes

### DIFF
--- a/config/bcc-common.toml
+++ b/config/bcc-common.toml
@@ -7,7 +7,7 @@
 	#The name of the modpack
 	modpackName = "Society: Capital Hill"
 	#The version of the modpack
-	modpackVersion = "2.6.1"
+	modpackVersion = "2.6.2"
 	#Use the metadata.json to determine the modpack version
 	#ONLY ENABLE THIS IF YOU KNOW WHAT YOU ARE DOING
 	useMetadata = false

--- a/config/crash_assistant/modlist.json
+++ b/config/crash_assistant/modlist.json
@@ -984,9 +984,9 @@
     "modId": "species",
     "version": "1.20.1-2.3-forge"
   },
-  "splendid_slimes-0.5.3.jar": {
+  "splendid_slimes-0.7.1.jar": {
     "modId": "splendid_slimes",
-    "version": "0.5.3"
+    "version": "0.7.1"
   },
   "stardew_fishing-1.20.1-2.3.jar": {
     "modId": "stardew_fishing",

--- a/config/crash_assistant/modlist.json
+++ b/config/crash_assistant/modlist.json
@@ -287,9 +287,9 @@
     "modId": "defaultoptions",
     "version": "18.0.1"
   },
-  "dew_drop_farmland_growth-2.0.jar": {
+  "dew_drop_farmland_growth-2.1.jar": {
     "modId": "dew_drop_farmland_growth",
-    "version": "2.0"
+    "version": "2.1"
   },
   "dew_drop_watering_cans-1.0.2.jar": {
     "modId": "dew_drop_watering_cans",

--- a/config/everycomp-hazardous.properties
+++ b/config/everycomp-hazardous.properties
@@ -1,5 +1,5 @@
 #Hard disable entire modules. Use at your own risk and don't ask for support if you use this. Write modid = false to disable modules
-#Sun May 11 10:42:15 EDT 2025
+#Sun May 11 12:32:11 EDT 2025
 farmersdelight=true
 a=false
 decorative_blocks=true

--- a/config/everycomp-hazardous.properties
+++ b/config/everycomp-hazardous.properties
@@ -1,5 +1,5 @@
 #Hard disable entire modules. Use at your own risk and don't ask for support if you use this. Write modid = false to disable modules
-#Sat Apr 26 11:47:20 EDT 2025
+#Sun May 11 10:42:15 EDT 2025
 farmersdelight=true
 a=false
 decorative_blocks=true

--- a/config/fabric/indigo-renderer.properties
+++ b/config/fabric/indigo-renderer.properties
@@ -1,5 +1,5 @@
 #Indigo properties file
-#Sun May 11 10:42:13 EDT 2025
+#Sun May 11 12:32:09 EDT 2025
 fix-mean-light-calculation=auto
 debug-compare-lighting=auto
 fix-exterior-vertex-lighting=auto

--- a/config/fabric/indigo-renderer.properties
+++ b/config/fabric/indigo-renderer.properties
@@ -1,5 +1,5 @@
 #Indigo properties file
-#Sat Apr 26 11:47:19 EDT 2025
+#Sun May 11 10:42:13 EDT 2025
 fix-mean-light-calculation=auto
 debug-compare-lighting=auto
 fix-exterior-vertex-lighting=auto

--- a/config/fancymenu/assets/changelog.markdown
+++ b/config/fancymenu/assets/changelog.markdown
@@ -46,3 +46,13 @@
 - Fixed Fish Tanks and large barrels not dropping when broken
 - Fixed minerals not being fireable from Silme Vac
 - Fixed Slingshot recipe not using Canvas
+
+### 2.6.2
+- Added non-Botania recipe for Minty Slime Heart
+- Sprinklers will now make farmland moist in the morning
+- Improved Plort Press performance and logic, fixing some bugs
+- Fixed z-fighting issue with Artisan Machine exclamation mark
+- Fixed Bones and Preserves not being fireable from Slime Vac
+- Fixed Ghost Pepper drop amount not matching Alamanc
+- Fixed crash with slimes that run commands
+- Fixed crash with Coin Leaderboard

--- a/config/fancymenu/audio_element_controller_metas.json
+++ b/config/fancymenu/audio_element_controller_metas.json
@@ -616,6 +616,10 @@
     "volume": 1.0
   },
   {
+    "element_identifier": "223e1438-351e-40d3-8140-26ebd03a0ca1-1746979231692",
+    "volume": 1.0
+  },
+  {
     "element_identifier": "2c8336a9-e151-415e-b2c2-1b87ddf822d4-1743298602868",
     "volume": 1.0
   },
@@ -829,6 +833,10 @@
   },
   {
     "element_identifier": "4e99c619-2d7c-4717-bcb1-9dff21d47225-1744762221811",
+    "volume": 1.0
+  },
+  {
+    "element_identifier": "378bedae-33e4-456e-a71c-b0259a1febb6-1746981153648",
     "volume": 1.0
   },
   {
@@ -1317,6 +1325,10 @@
   },
   {
     "element_identifier": "eb5899c3-0263-43d1-b87e-7869ff54c4b4-1744831441034",
+    "volume": 1.0
+  },
+  {
+    "element_identifier": "bf5d9780-9722-410c-b34a-88de65b1a5d9-1746981153613",
     "volume": 1.0
   },
   {
@@ -2141,6 +2153,10 @@
   },
   {
     "element_identifier": "3839748c-f4ae-4638-9a9a-b0cfb9eb9be6-1744416416513",
+    "volume": 1.0
+  },
+  {
+    "element_identifier": "70ca840c-59d7-46a1-8430-2704c441b0e7-1746979231716",
     "volume": 1.0
   },
   {

--- a/config/fancymenu/audio_element_controller_metas.json
+++ b/config/fancymenu/audio_element_controller_metas.json
@@ -1304,6 +1304,10 @@
     "volume": 1.0
   },
   {
+    "element_identifier": "708fea99-31ec-4fea-b36e-67109bbc5257-1746973492059",
+    "volume": 1.0
+  },
+  {
     "element_identifier": "df2541be-78e0-4e5a-b308-4ad8bf7a58c5-1744763471144",
     "volume": 1.0
   },
@@ -1540,6 +1544,10 @@
     "volume": 1.0
   },
   {
+    "element_identifier": "a701a7d8-0610-49df-8a7a-f1ed469146f7-1746970857399",
+    "volume": 1.0
+  },
+  {
     "element_identifier": "77ff6ac4-9957-4833-a214-83ca2e667561-1744572557564",
     "volume": 1.0
   },
@@ -1576,6 +1584,10 @@
     "volume": 1.0
   },
   {
+    "element_identifier": "ef916ff7-5064-42da-8644-d1ef6d007e73-1746970857367",
+    "volume": 1.0
+  },
+  {
     "element_identifier": "334b072c-1bc4-4b7d-ad0b-21249e612736-1744573182259",
     "volume": 1.0
   },
@@ -1597,6 +1609,10 @@
   },
   {
     "element_identifier": "019840a1-ad81-44b1-ab9b-123014bafce9-1744682402810",
+    "volume": 1.0
+  },
+  {
+    "element_identifier": "1bb2b718-eb18-47d1-8c22-4d8749b3d6ab-1746973492092",
     "volume": 1.0
   },
   {
@@ -2220,6 +2236,10 @@
     "volume": 1.0
   },
   {
+    "element_identifier": "ce8de918-a4b7-422b-ae97-b6b46df05bee-1746974557261",
+    "volume": 1.0
+  },
+  {
     "element_identifier": "e3cfd578-fc17-4421-b6eb-fabfcb9168a9-1744723664362",
     "volume": 1.0
   },
@@ -2313,6 +2333,10 @@
   },
   {
     "element_identifier": "da0c8a70-bb7a-4534-a5d7-5afc9e450c61-1742408693013",
+    "volume": 1.0
+  },
+  {
+    "element_identifier": "17434204-e6cd-4123-98cf-95c833746442-1746974557290",
     "volume": 1.0
   },
   {

--- a/config/oculus.properties
+++ b/config/oculus.properties
@@ -1,5 +1,5 @@
 #This file stores configuration options for Iris, such as the currently active shaderpack
-#Sat Apr 26 11:47:18 EDT 2025
+#Sun May 11 10:42:13 EDT 2025
 colorSpace=SRGB
 disableUpdateMessage=false
 enableDebugOptions=false

--- a/config/oculus.properties
+++ b/config/oculus.properties
@@ -1,5 +1,5 @@
 #This file stores configuration options for Iris, such as the currently active shaderpack
-#Sun May 11 10:42:13 EDT 2025
+#Sun May 11 12:32:09 EDT 2025
 colorSpace=SRGB
 disableUpdateMessage=false
 enableDebugOptions=false

--- a/config/splendid_slimes.cfg
+++ b/config/splendid_slimes.cfg
@@ -1,0 +1,49 @@
+# File Specification: https://gist.github.com/Shadows-of-Fire/88ac714a758636c57a52e32ace5474c1
+
+# ꒷꒦꒷꒦꒷꒦꒷꒦꒷꒦꒷꒦ Splendid Slimes Config! ꒦꒷꒦꒷꒦꒷꒦꒷꒦꒷꒦꒷
+
+# All entries in this config file are synced from server to client.
+
+
+slimes {
+    # How long it takes for Splendid Slimes to start starving, in ticks. Slimes can eat halfway through this duration
+    # Default: 24000; Range: [20 ~ 2147483647]
+    I:"Slime Starving time"=24000
+
+    # Maximum happiness value for a Splendid Slime.
+    # Default: 1000; Range: [3 ~ 2147483147]
+    I:"Slime Max Happiness"=1000
+
+    # Minimum amount of happiness a Splendid Slime can have before being considered 'Happy'.
+    # Default: 600; Range: [0 ~ 2147483647]
+    I:"Slime Happy Threshold"=600
+
+    # Maximum amount of happiness a Splendid Slime can have before being considered 'Unhappy'.
+    # Default: 400; Range: [0 ~ 2147483647]
+    I:"Slime Unhappy Threshold"=400
+
+    # Maximum amount of happiness a Splendid Slime can have before being considered 'Furious'.
+    # Default: 200; Range: [0 ~ 2147483647]
+    I:"Slime Furious Threshold"=200
+
+    # How many ticks it takes for a Splendid Slime to try and perform Negative/Positive effects/commands. Setting this value too low may cause performance issues.
+    # Default: 800; Range: [20 ~ 2147483647]
+    I:"Slime Effect Cooldown"=800
+
+    # If true, Largo Slimes will turn into Tarrs after eating a 3rd Plort instead of just dying.
+    # Default: true
+    B:"Enable Tarrs"=true
+}
+
+
+machines {
+    # Time it takes for Splendid Slimes to incubate in Slime Incubator
+    # Default: 6000; Range: [1 ~ 2147483647]
+    I:"Slime Incubation Time"=6000
+
+    # Time it takes to craft items in a Plort Press
+    # Default: 1200; Range: [20 ~ 2147483637]
+    I:"Plort Pressing Time"=1200
+}
+
+

--- a/emi.json
+++ b/emi.json
@@ -8,6 +8,9 @@
     }
   ],
   "lookup_history": [
+    "item:minecraft:dragon_egg",
+    "item:splendid_slimes:slime_heart{slime:{id:\"splendid_slimes:minty\"}}",
+    "item:botania:life_essence",
     "item:society:battery",
     "item:splendid_slimes:slime_vac",
     "item:splendid_slimes:plort_press",
@@ -102,7 +105,6 @@
     "item:splendid_slimes:slime_heart{slime:{id:\"splendid_slimes:boomcat\"}}",
     "item:splendid_slimes:slime_heart{slime:{id:\"splendid_slimes:shulking\"}}",
     "item:splendid_slimes:slime_heart{slime:{id:\"splendid_slimes:rotting\"}}",
-    "item:splendid_slimes:slime_heart{slime:{id:\"splendid_slimes:minty\"}}",
     "item:splendid_slimes:slime_heart{slime:{id:\"splendid_slimes:ender\"}}",
     "item:splendid_slimes:slime_heart{slime:{id:\"splendid_slimes:luminous\"}}",
     "item:splendid_slimes:slime_heart{slime:{id:\"splendid_slimes:puddle\"}}",
@@ -251,11 +253,6 @@
     "item:botania:blood_pendant{brewKey:\"botania:regen\"}",
     "item:botania:incense_stick{brewKey:\"botania:soul_cross\"}",
     "item:minecraft:bamboo_block",
-    {
-      "type": "item",
-      "id": "botania:life_essence",
-      "amount": 15
-    },
     "item:betterarcheology:torrent_totem{Damage:0}",
     "item:society:sturdy_bamboo_block",
     "item:automobility:dash_panel",
@@ -717,8 +714,8 @@
   ],
   "recipe_defaults": {
     "added": [
-      "minecraft:kjs/society_deluxe_worm_farm",
-      "jei:/sewingkit/kjs/23iuf4j9xvgbkbs5d9uaflgge"
+      "jei:/sewingkit/kjs/23iuf4j9xvgbkbs5d9uaflgge",
+      "minecraft:kjs/society_deluxe_worm_farm"
     ],
     "tags": {},
     "resolutions": {},

--- a/kubejs/assets/society/models/block/error.json
+++ b/kubejs/assets/society/models/block/error.json
@@ -19,7 +19,7 @@
 		},
 		{
 			"from": [7, 26, 7],
-			"to": [9, 32, 9],
+			"to": [9, 31.99, 9],
 			"rotation": {"angle": 0, "axis": "y", "origin": [7, 26, 7]},
 			"faces": {
 				"north": {"uv": [0, 0, 2, 6], "texture": "#6"},

--- a/kubejs/assets/society/models/block/machine_done.json
+++ b/kubejs/assets/society/models/block/machine_done.json
@@ -19,7 +19,7 @@
 		},
 		{
 			"from": [7, 26, 7],
-			"to": [9, 32, 9],
+			"to": [9, 31.99, 9],
 			"rotation": {"angle": 0, "axis": "y", "origin": [7, 26, 7]},
 			"faces": {
 				"north": {"uv": [0, 0, 2, 6], "texture": "#6"},

--- a/kubejs/assets/society/models/block/pond_quest.json
+++ b/kubejs/assets/society/models/block/pond_quest.json
@@ -19,7 +19,7 @@
 		},
 		{
 			"from": [7, 26, 7],
-			"to": [9, 32, 9],
+			"to": [9, 31.99, 9],
 			"rotation": {"angle": 0, "axis": "y", "origin": [7, 26, 7]},
 			"faces": {
 				"north": {"uv": [0, 0, 2, 6], "texture": "#6"},

--- a/kubejs/data/vintagedelight/loot_tables/blocks/ghost_pepper_crop.json
+++ b/kubejs/data/vintagedelight/loot_tables/blocks/ghost_pepper_crop.json
@@ -29,6 +29,36 @@
         }
       ],
       "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "block": "vintagedelight:ghost_pepper_crop",
+          "condition": "minecraft:block_state_property",
+          "properties": {
+            "age": "7"
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "function": "minecraft:apply_bonus",
+              "parameters": {
+                "extra": 1,
+                "probability": 0.5714286
+              }
+            }
+          ],
+          "name": "vintagedelight:ghost_pepper"
+        }
+      ],
+      "rolls": 1.0
     }
   ]
 }

--- a/kubejs/server_scripts/recipes/addSlimeRecipes.js
+++ b/kubejs/server_scripts/recipes/addSlimeRecipes.js
@@ -85,4 +85,5 @@ ServerEvents.recipes((e) => {
   addItemFusion("society:magic_rock_candy", "slimy", "sweet");
   addItemFusion("numismatics:ancient_coin", "bitwise", "gold");
   addItemFusion("botania:life_essence", "ender", "minty");
+  addItemFusion("minecraft:dragon_egg", "ender", "minty");
 });

--- a/kubejs/server_scripts/tags/handleItemBlockFluidTags.js
+++ b/kubejs/server_scripts/tags/handleItemBlockFluidTags.js
@@ -384,6 +384,8 @@ e.add("forge:eggs", "society:cracked_egg");
     e.add("society:omni_geode_treasure", geodeItem.item);
   });
   e.add("splendid_slimes:slime_vac_fireable", "#society:omni_geode_treasure")
+  e.add("splendid_slimes:slime_vac_fireable", "#society:preserves");
+  e.add("splendid_slimes:slime_vac_fireable", "minecraft:bone");
   const geodeRelic = ["relics:horse_flute", "relics:hunter_belt"];
   geodeRelic.forEach((geodeItem) => {
     e.add("society:geode_relic", geodeItem);

--- a/kubejs/startup_scripts/customMachines/coinLeaderboard.js
+++ b/kubejs/startup_scripts/customMachines/coinLeaderboard.js
@@ -8,6 +8,7 @@ const GLOBAL_BANK = NUMISMATICS.BANK;
 const updateLeaderboardMap = (server) => {
   let playerName;
   let playerList = server.persistentData.playerList;
+  if (!playerList) return undefined
   let leaderboardMap = new Map();
   GLOBAL_BANK.accounts.forEach((playerUUID, bankAccount) => {
     playerName = playerList[playerUUID];
@@ -43,7 +44,7 @@ global.updateLeaderboard = (block, server) => {
   let entity;
   let calcY = y + 1;
   let leaderboardMap = updateLeaderboardMap(server);
-
+  if (!leaderboardMap) return;
   clearOldLeaderboard(block);
 
   // Display leaderboard name

--- a/pakku-lock.json
+++ b/pakku-lock.json
@@ -9326,7 +9326,7 @@
             "files": [
                 {
                     "type": "curseforge",
-                    "file_name": "splendid_slimes-0.5.3.jar",
+                    "file_name": "splendid_slimes-0.7.0.jar",
                     "mc_versions": [
                         "1.20.1"
                     ],
@@ -9334,18 +9334,18 @@
                         "forge"
                     ],
                     "release_type": "beta",
-                    "url": "https://edge.forgecdn.net/files/6454/601/splendid_slimes-0.5.3.jar",
-                    "id": "6454601",
+                    "url": "https://edge.forgecdn.net/files/6477/269/splendid_slimes-0.7.0.jar",
+                    "id": "6477269",
                     "parent_id": "1240935",
                     "hashes": {
-                        "sha1": "74031cab8e01afc85a2642edafd131b8e3aae379",
-                        "md5": "272729244b1831b3ddd31157f39aa0c5"
+                        "sha1": "ff8d25a24242d526468cd0b2d4115aac3e0a0494",
+                        "md5": "656fee6f2de0781e2f6b6018ea578e17"
                     },
                     "required_dependencies": [
                         "283644"
                     ],
-                    "size": 347239,
-                    "date_published": "2025-04-23T03:46:12.740Z"
+                    "size": 356956,
+                    "date_published": "2025-04-29T17:30:17.013Z"
                 }
             ]
         },

--- a/pakku-lock.json
+++ b/pakku-lock.json
@@ -9598,7 +9598,7 @@
             "files": [
                 {
                     "type": "curseforge",
-                    "file_name": "dew_drop_farmland_growth-2.0.jar",
+                    "file_name": "dew_drop_farmland_growth-2.1.jar",
                     "mc_versions": [
                         "1.20.1"
                     ],
@@ -9606,19 +9606,19 @@
                         "forge"
                     ],
                     "release_type": "release",
-                    "url": "https://edge.forgecdn.net/files/6422/269/dew_drop_farmland_growth-2.0.jar",
-                    "id": "6422269",
+                    "url": "https://edge.forgecdn.net/files/6512/649/dew_drop_farmland_growth-2.1.jar",
+                    "id": "6512649",
                     "parent_id": "1172429",
                     "hashes": {
-                        "sha1": "fa633bdbd13f8deecca8181bc32d919c8077a83f",
-                        "md5": "c92fcada52433bbf7458df0aca70dc9e"
+                        "sha1": "9cc90629a007ecb89f5122bf82f5f72b054a6066",
+                        "md5": "f603d49b99438d6126d2fdcdb5bffd02"
                     },
                     "required_dependencies": [
                         "291874",
                         "1062753"
                     ],
-                    "size": 75125,
-                    "date_published": "2025-04-14T13:51:33.867Z"
+                    "size": 75161,
+                    "date_published": "2025-05-09T14:17:00.150Z"
                 }
             ]
         },

--- a/pakku.json
+++ b/pakku.json
@@ -1,6 +1,6 @@
 {
     "name": "Society Capital Hill",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "overrides": [
         "config",
         "defaultconfigs",


### PR DESCRIPTION
# 2.6.2 
- Added non-Botania recipe for Minty Slime Heart
- Sprinklers will now make farmland moist in the morning
- Improved Plort Press performance and logic, fixing some bugs
- Fixed z-fighting issue with Artisan Machine exclamation mark
- Fixed Bones and Preserves not being fireable from Slime Vac
- Fixed Ghost Pepper drop amount not matching Alamanc
- Fixed crash with slimes that run commands
- Fixed crash with Coin Leaderboard