### PR TITLE
Updated getAnimalIsNotCramped to filter for husbandry animals only.

### DIFF
--- a/kubejs/startup_scripts/globalAnimalHandlers.js
+++ b/kubejs/startup_scripts/globalAnimalHandlers.js
@@ -11,9 +11,11 @@ global.isFresh = (age, actionAge, interactionCooldown) => {
 
 global.getAnimalIsNotCramped = (target) => {
   const level = target.getLevel();
-  const entities = level.getEntitiesWithin(target.boundingBox.inflate(1.1)).length;
+  const entities = level
+    .getEntitiesWithin(target.boundingBox.inflate(1.1))
+    .filter(e => global.checkEntityTag(e, "society:husbandry_animal"));
 
-  return entities <= 6;
+  return entities.length <= 6;
 };
 
 global.getMilkingTimeMult = (type) => {


### PR DESCRIPTION
The original function counted all nearby entities, regardless of type. This change ensures that only entities tagged with "society:husbandry_animal" are considered when determining if the area is cramped. This was mainly to avoid false positives from stuff like create:seat entities, which show up as entities when something's sitting on them. (Damn Rabbits)