### PR TITLE
Fixed an issue with Dehydrator

### DIFF
--- a/kubejs/startup_scripts/customMachines/dehydrator.js
+++ b/kubejs/startup_scripts/customMachines/dehydrator.js
@@ -164,13 +164,12 @@ StartupEvents.registry("block", (event) => {
         }
       }
 
+      let outputMult = 1;
       if (upgraded && block.properties.get("mature") === "true") {
-        let recipe = global.dehydratorglobal.getArtisanOutputs(recipes, block);
-        recipe.output.forEach((id) => {
-          if (global.dehydratableMushrooms.includes(recipe.input)) {
-            block.popItemFromFace(Item.of(id), facing);
-          }
-        });
+        let type = global.dehydratorRecipes[block.properties.get("type")];
+        if (global.dehydratableMushrooms.includes(type.input)) {
+          outputMult = 2;
+        }
       }
 
       global.handleBERightClick(
@@ -178,7 +177,9 @@ StartupEvents.registry("block", (event) => {
         click,
         global.dehydratorRecipes,
         8,
-        true
+        true,
+        false,
+        outputMult
       );
     })
     .blockEntity((blockInfo) => {


### PR DESCRIPTION
An upgraded dehydrator would not allow result items to be extracted when clicked.

## PR checklist
Check all that apply
- [x] I have read the [contribution guide](https://github.com/Chakyl/society-sunlit-valley?tab=readme-ov-file#contribution-guide)
- [x] Bugfix, typos, documentation
- [ ] New content
- [ ] Changes to existing content
- [ ] Translation
- [ ] Work in this PR contains AI generated text, images, or code
## Changelog
- Modified dehydrator.rightClick behavior to use the artisanHarvest(outputMult)