### PR TITLE
Modified dehydrator upgrade logic.

### DIFF
--- a/kubejs/startup_scripts/customMachines/dehydrator.js
+++ b/kubejs/startup_scripts/customMachines/dehydrator.js
@@ -136,6 +136,8 @@ StartupEvents.registry("block", (event) => {
       const { player, item, block, hand, level } = click;
       const upgraded = block.properties.get("upgraded").toLowerCase() == "true";
       const facing = block.properties.get("facing");
+      const type = global.dehydratorRecipes[block.properties.get("type")];
+      const isMushroom = global.dehydratableMushrooms.includes(type);
 
       if (hand == "OFF_HAND") return;
       if (hand == "MAIN_HAND") {
@@ -178,7 +180,9 @@ StartupEvents.registry("block", (event) => {
         click,
         global.dehydratorRecipes,
         8,
-        true
+        true,
+        false,
+        upgraded && isMushroom ? 2 : 1
       );
     })
     .blockEntity((blockInfo) => {


### PR DESCRIPTION
## Modified dehydrator upgrade logic.
When right clicking a mature upgraded dehydrator, no input is processed as the logic is faulty. This resolves this.
## PR checklist
Check all that apply
- [ ] I have read the [contribution guide](https://github.com/Chakyl/society-sunlit-valley?tab=readme-ov-file#contribution-guide)
- [ ] Bugfix, typos, documentation
- [ ] New content
- [ ] Changes to existing content
- [ ] Translation
- [ ] Work in this PR contains AI generated text, images, or code
## Changelog
- Fixed upgraded dehydrator not dropping result items.
