### PR TITLE
Upgraded globalServer.js

### DIFF
--- a/kubejs/server_scripts/globalServer.js
+++ b/kubejs/server_scripts/globalServer.js
@@ -318,6 +318,7 @@ global.artisanMachineDefinitions = [
     recipes: "society:battery",
     stageCount: 5,
     maxInput: 1,
+    upgrade: "society:frosted_tip",
   },
   {
     id: "society:espresso_machine",


### PR DESCRIPTION
## Upgraded globalServer.js
Fixes the Charging Rod missing the upgrade
## PR checklist
Check all that apply
- [x] I have read the [contribution guide](https://github.com/Chakyl/society-sunlit-valley?tab=readme-ov-file#contribution-guide)
- [x] Bugfix, typos, documentation
- [ ] New content
- [ ] Changes to existing content
- [ ] Translation
- [ ] Work in this PR contains AI generated text, images, or code
## Changelog
- Fixed Charging Rods not dropping the Upgrade when being broken
