### PR TITLE
Pams Fruits no longer affected by collector perk

### DIFF
--- a/kubejs/server_scripts/loot/farmingLoot.js
+++ b/kubejs/server_scripts/loot/farmingLoot.js
@@ -82,7 +82,24 @@ const cropList = [
   "society:sweet_potato",
   "society:onion",
 ];
-const reeseedableCops = ["herbalbrews:yerba_mate","herbalbrews:rooibos","herbalbrews:coffee"];
+const reeseedableCops = [
+  "herbalbrews:yerba_mate", 
+  "herbalbrews:rooibos", 
+  "herbalbrews:coffee",
+  "pamhc2trees:pamorange",
+  "pamhc2trees:pamdragonfruit",
+  "pamhc2trees:pampeach",
+  "pamhc2trees:pamplum",
+  "pamhc2trees:pambanana",
+  "pamhc2trees:pamapple",
+  "pamhc2trees:pamcherry",
+  "pamhc2trees:pamstarfruit",
+  "pamhc2trees:pamlychee",
+  "pamhc2trees:pammango",
+  "pamhc2trees:pamhazelnut",
+  "pamhc2trees:pampawpaw",
+  "pamhc2trees:pamcinnamon"
+];
 const checkMaxGrown = (destroyedBlock) => {
   return destroyedBlock.blockState.block.isMaxAge(destroyedBlock.blockState);
 };


### PR DESCRIPTION
Pams Fruits no longer affected by collector perk

## Pull Request name
Added the Pams harvest tree fruits into the reeseedable crops list to prevent crop collector dupe
## PR checklist
Check all that apply
- [ ] I have read the [contribution guide](https://github.com/Chakyl/society-sunlit-valley?tab=readme-ov-file#contribution-guide)
- [ ] Bugfix, typos, documentation
- [ ] New content
- [ ] Changes to existing content
- [ ] Translation
- [ ] Work in this PR contains AI generated text, images, or code
## Changelog
- Added the Pams harvest tree fruits into the reeseedable crops list to prevent crop collector dupe
