### PR TITLE
Fixed Ancient Goddess JEI Recipes

### DIFF
--- a/kubejs/client_scripts/blockEntityJei.js
+++ b/kubejs/client_scripts/blockEntityJei.js
@@ -236,7 +236,7 @@ JEIAddedEvents.registerRecipes((e) => {
       input: "farm_and_charm:corn",
       output: ["4x society:pristine_star_shards"],
     },
-    { input: "snowyspirit:ginger", output: ["4x minecraft:ancient_debris"] },
+    { input: "snowyspirit:ginger", output: ["4x minecraft:netherite_scrap"] },
   ].forEach((element) => {
     e.custom("society:goddess_offering").add(element);
   });

--- a/kubejs/client_scripts/blockEntityJei.js
+++ b/kubejs/client_scripts/blockEntityJei.js
@@ -230,7 +230,7 @@ JEIAddedEvents.registerRecipes((e) => {
     { input: "society:ancient_fruit", output: ["society:prismatic_shard"] },
     {
       input: "vintagedelight:ghost_pepper",
-      output: ["32x society:sparkstone"],
+      output: ["16x society:sparkstone_block"],
     },
     {
       input: "farm_and_charm:corn",


### PR DESCRIPTION
## Fixed Ancient Goddess JEI Recipes
This fix applies for Ginger and Ghost Pepper
## PR checklist
Check all that apply
- [x] I have read the [contribution guide](https://github.com/Chakyl/society-sunlit-valley?tab=readme-ov-file#contribution-guide)
- [x] Bugfix, typos, documentation
- [ ] New content
- [ ] Changes to existing content
- [ ] Translation
- [ ] Work in this PR contains AI generated text, images, or code
## Changelog
- Fixed the Recipes of the Ancient Goddess Statue for Ginger and Ghost Pepper, now shows the right outcome for both
