### PR TITLE
3.3.0

### DIFF
--- a/config/.gitignore
+++ b/config/.gitignore
@@ -6,7 +6,8 @@ emojiful/cache
 journeymap/
 local/
 logs
-resourcepacks/
+resourcepacks/*
+!resourcepacks/emi_tag_icon_fixes/
 mods/
 build/
 saves/

--- a/config/resourcepackoverrides.json
+++ b/config/resourcepackoverrides.json
@@ -15,7 +15,8 @@
     "file/Better tom's create storage 1.1.zip",
     "file/Fairy Wings Elytra.zip",
     "file/Better_Cats_V0.09.zip",
-    "file/Create Style for Refined Storage.zip"
+    "file/Create Style for Refined Storage.zip",
+    "file/emi_tag_icon_fixes"
   ],
   "default_overrides": {
     "force_compatible": true
@@ -35,7 +36,8 @@
     "file/Better tom's create storage 1.1.zip",
     "file/Fairy Wings Elytra.zip",
     "file/Better_Cats_V0.09.zip",
-    "file/Create Style for Refined Storage.zip"
+    "file/Create Style for Refined Storage.zip",
+    "file/emi_tag_icon_fixes"
   ],
     "$$1": {
       "hidden": false,

--- a/config/resourcepacks/emi_tag_icon_fixes/assets/forge/models/tag/item/eggs.json
+++ b/config/resourcepacks/emi_tag_icon_fixes/assets/forge/models/tag/item/eggs.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/egg"
+    }
+}

--- a/config/resourcepacks/emi_tag_icon_fixes/pack.mcmeta
+++ b/config/resourcepacks/emi_tag_icon_fixes/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+   "pack": {
+      "pack_format": 15,
+      "description": "Fixes for EMI tag icons"
+   }
+}


### PR DESCRIPTION
## Fix for EMI recipes using eggs to show an actual egg and not the weird birt egg
Change tag model for #forge:egg from a birt egg to a vanilla egg
## PR checklist
Check all that apply
- [x] I have read the [contribution guide](https://github.com/Chakyl/society-sunlit-valley?tab=readme-ov-file#contribution-guide)
- [x] Bugfix, typos, documentation
- [ ] New content
- [ ] Changes to existing content
- [ ] Translation
- [ ] Work in this PR contains AI generated text, images, or code
## Changelog
- added small resourcepack that changes the tag model for #forge:eggs to use minecraft:egg
- added exception to .gitignore for the resourcepack
- added resourcepack to resourcepackoverrides config
