### PR TITLE
[KubeJS] - [FEAT] - Add recipes for double tall mystical flowers in botania

### DIFF
--- a/kubejs/server_scripts/colors_globals.js
+++ b/kubejs/server_scripts/colors_globals.js
@@ -1,0 +1,5 @@
+
+global.COLORS = Object.freeze([
+    'white', 'orange', 'magenta', 'light_blue', 'yellow', 'lime', 'pink', 'gray',
+    'light_gray', 'cyan', 'purple', 'blue', 'brown', 'green', 'red', 'black'
+]);

--- a/kubejs/server_scripts/recipes/addMysticalFlowersRecipes.js
+++ b/kubejs/server_scripts/recipes/addMysticalFlowersRecipes.js
@@ -1,0 +1,25 @@
+console.info("[SOCIETY] addMysticalFlowerRecipes.js loaded");
+
+ServerEvents.recipes((e) => {
+    global.COLORS.forEach((color) => {
+        const ingredientItemString = `botania:${color}_petal`;
+        const outputItemString = `botania:${color}_double_flower`;
+        const reagentItemString = "minecraft:wheat_seeds";
+        e.custom({
+            type: "botania:petal_apothecary",
+            ingredients: [
+                { item: ingredientItemString },
+                { item: ingredientItemString },
+                { item: ingredientItemString },
+                { item: ingredientItemString },
+            ],
+            output: {
+                item: outputItemString,
+                count: 1,
+            },
+            reagent: {
+                item: reagentItemString,
+            }
+        });
+    });
+});


### PR DESCRIPTION

## [KubeJS] - [FEAT] - Add recipes for double tall mystical flowers in botania
- Referencing issue : https://github.com/Chakyl/society-sunlit-valley/issues/139

## PR checklist
Check all that apply
- [X] I have read the [contribution guide](https://github.com/Chakyl/society-sunlit-valley?tab=readme-ov-file#contribution-guide)
- [ ] Bugfix, typos, documentation
- [X] New content
- [X] Changes to existing content
- [ ] Translation
- [ ] Work in this PR contains AI generated text, images, or code
## Changelog
- Ading new recipes for double tall flowers in botania using the apothecary, petals and wheat seeds
- Tried to maintain a balance so 4 petals for a double tall flower that gives 4 petals seems legit -> avoiding vanilla botania infinite petals
- created a global Colors frozen object to have 1 source of truth as the colors for maintainability