### PR TITLE
moved global.getshippingbinname to startup scripts 

### DIFF
--- a/kubejs/server_scripts/blockEvents/shippingBinRenaming.js
+++ b/kubejs/server_scripts/blockEvents/shippingBinRenaming.js
@@ -15,37 +15,6 @@ const getStoredCustomName = (nbt) => {
   return nbt.data.customName || nbt.data.custom_name || null;
 };
 
-global.getShippingBinName = (nbt, legacy) => {
-  if (nbt && nbt.contains('customName')) {
-    let json = nbt.getString('customName');
-    let data = JSON.parse(json);
-    if (legacy) {
-      return textComponentToLegacy(data);
-    }
-    else {
-      return Text.of(data);
-    }
-  }
-  return null;
-};
-
-const textComponentToLegacy = (data) => {
-  const colorMap = {
-    black: "§0", dark_blue: "§1", dark_green: "§2", dark_aqua: "§3",
-    dark_red: "§4", dark_purple: "§5", gold: "§6", gray: "§7",
-    dark_gray: "§8", blue: "§9", green: "§a", aqua: "§b",
-    red: "§c", light_purple: "§d", yellow: "§e", white: "§f"
-  };
-  let prefix = "";
-  if (data.color) prefix += colorMap[data.color.toLowerCase()] ?? "§f";
-  if (data.bold) prefix += "§l";
-  if (data.italic) prefix += "§o";
-  if (data.underlined) prefix += "§n";
-  if (data.strikethrough) prefix += "§m";
-  if (data.obfuscated) prefix += "§k";
-  const text = data.text ?? "";
-  return prefix + text;
-};
 
 BlockEvents.placed(shippingBins, (e) => {
   const { player, block } = e;

--- a/kubejs/startup_scripts/globalShippingBinHandlers.js
+++ b/kubejs/startup_scripts/globalShippingBinHandlers.js
@@ -27,6 +27,40 @@ const calculateCoinsFromValue = (price, output, coinMap) => {
   }
 };
 
+const textComponentToLegacy = (data) => {
+  const colorMap = {
+    black: "§0", dark_blue: "§1", dark_green: "§2", dark_aqua: "§3",
+    dark_red: "§4", dark_purple: "§5", gold: "§6", gray: "§7",
+    dark_gray: "§8", blue: "§9", green: "§a", aqua: "§b",
+    red: "§c", light_purple: "§d", yellow: "§e", white: "§f"
+  };
+  let prefix = "";
+  if (data.color) prefix += colorMap[data.color.toLowerCase()] ?? "§f";
+  if (data.bold) prefix += "§l";
+  if (data.italic) prefix += "§o";
+  if (data.underlined) prefix += "§n";
+  if (data.strikethrough) prefix += "§m";
+  if (data.obfuscated) prefix += "§k";
+  const text = data.text ?? "";
+  return prefix + text;
+};
+
+
+global.getShippingBinName = (nbt, legacy) => {
+  if (nbt && nbt.contains('customName')) {
+    let json = nbt.getString('customName');
+    let data = JSON.parse(json);
+    if (legacy) {
+      return textComponentToLegacy(data);
+    }
+    else {
+      return Text.of(data);
+    }
+  }
+  return null;
+};
+
+
 global.getAttributeMultiplier = (attributes, multiplier) => {
   return (
     Number(


### PR DESCRIPTION
moved global.getshippingbinname to startup scripts so both client and server can communicate with it

## Pull Request name
Fix for the jade tooltip for renamed shipping bins 
## PR checklist
Check all that apply
- [x] I have read the [contribution guide](https://github.com/Chakyl/society-sunlit-valley?tab=readme-ov-file#contribution-guide)
- [x] Bugfix, typos, documentation
- [ ] New content
- [ ] Changes to existing content
- [ ] Translation
- [ ] Work in this PR contains AI generated text, images, or code
## Changelog
- Fixed Jade tooltip for renamed shipping bins


> I am sorry for such a foolish mistake