### PR TITLE
offline autoHopper autoGrabber fishPondBasket

### DIFF
--- a/config/fancymenu/assets/changelog.markdown
+++ b/config/fancymenu/assets/changelog.markdown
@@ -4,6 +4,6 @@
 ^^^
 --- 
 
-- Artisan Hoppers can now work while the owner is offline
+- Artisan Hoppers, Auto Grabbers, Fish Pond Baskets can now work while the owner is offline
 
 TODO

--- a/config/fancymenu/assets/changelog.markdown
+++ b/config/fancymenu/assets/changelog.markdown
@@ -4,4 +4,6 @@
 ^^^
 --- 
 
+- Artisan Hoppers can now work while the owner is offline
+
 TODO

--- a/kubejs/server_scripts/entities/animalBase.js
+++ b/kubejs/server_scripts/entities/animalBase.js
@@ -250,7 +250,7 @@ const handleMilk = (name, data, day, hungry, e) => {
   if (player.cooldowns.isOnCooldown(item)) return;
   if (player.isFake() && data.getInt("affection") < 100) return;
   let errorText;
-  let milkItem = global.getMilk(level, target, data, player, day, true);
+  let milkItem = global.getMilk(level, target, data, player, day, true, undefined, player.stages);
 
   if (milkItem !== -1) {
     let milk = level.createEntity("minecraft:item");
@@ -379,7 +379,7 @@ const handleMagicHarvest = (name, data, e) => {
   let hearts = Math.floor((affection > 1000 ? 1000 : affection) / 100);
 
   let errorText = "";
-  const droppedLoot = global.getMagicShearsOutput(level, target, player);
+  const droppedLoot = global.getMagicShearsOutput(level, target, player, undefined, player.stages);
   if (droppedLoot !== -1) {
     server.runCommandSilent(
       `playsound minecraft:entity.sheep.shear block @a ${player.x} ${player.y} ${player.z}`
@@ -566,7 +566,8 @@ global.handleHusbandryBase = (hand, player, item, target, level, server) => {
           undefined,
           undefined,
           undefined,
-          handleSpecialItem
+          handleSpecialItem,
+          player.stages,
         );
       }
       if (

--- a/kubejs/startup_scripts/customMachines/fishPond.js
+++ b/kubejs/startup_scripts/customMachines/fishPond.js
@@ -161,7 +161,7 @@ global.handleFishPondRightClick = (clickEvent) => {
       }
       global.handleFishInsertion(clickEvent);
       if (mature === "true") {
-        global.handleFishHarvest(block, player, server);
+        global.handleFishHarvest(block, player, server, false, player.stages);
       }
       if (!type.equals("") && population == "0") {
         if (item && item.hasTag("forge:tools/fishing_rods")) {
@@ -188,7 +188,7 @@ global.handleFishPondRightClick = (clickEvent) => {
         }
       }
     } else if (population > 0) {
-      let fishItem = global.handleFishExtraction(block, player, server);
+      let fishItem = global.handleFishExtraction(block, player, server, player.stages);
       if (fishItem) player.give(fishItem);
     }
   }

--- a/kubejs/startup_scripts/globalAnimalHandlers.js
+++ b/kubejs/startup_scripts/globalAnimalHandlers.js
@@ -90,6 +90,11 @@ const canMilk = (data, target, day, plushieModifiers) => {
   return !target.isBaby() && !hungry && (freshAnimal || dayHasPassed);
 };
 
+/**
+ * @param {Internal.Player|null} player
+ * player.stages, or auto-grabber NBT stages, or null for mana milker
+ * @param {Internal.Stages|Internal.CompoundTag|null} stages 
+ */
 global.getMilk = (
   level,
   target,
@@ -97,7 +102,8 @@ global.getMilk = (
   player,
   day,
   raiseAffection,
-  plushieModifiers
+  plushieModifiers,
+  stages
 ) => {
   const crackerBonus = data.animalCracker ? 2 : 1;
   let affection;
@@ -109,10 +115,7 @@ global.getMilk = (
   } else {
     affection = data.getInt("affection") || 0;
     mood = global.getOrFetchMood(level, target, day, player);
-    if (player) {
-      affectionIncrease =
-        player.stages.has("animal_whisperer") || data.bribed ? 10 : 5;
-    }
+    affectionIncrease = global.isStagePresent(stages, "animal_whisperer") || data.bribed ? 10 : 5;
   }
   let hearts = Math.floor(affection / 100);
 
@@ -135,7 +138,7 @@ global.getMilk = (
       }
     }
     return Item.of(
-      `${(player && player.stages.has("shepherd") ? 2 : 1) *
+      `${(global.isStagePresent(stages, "shepherd") ? 2 : 1) *
       crackerBonus *
       (plushieDoubleDrops ? 2 : 1)
       }x ${milkId}`,
@@ -145,6 +148,10 @@ global.getMilk = (
   return -1;
 };
 
+/**
+ * @param {Internal.Player|null} player
+ * @param {Internal.Stages|Internal.CompoundTag} stages player.stages or auto-grabber NBT stages
+ */
 global.handleSpecialHarvest = (
   level,
   target,
@@ -153,7 +160,8 @@ global.handleSpecialHarvest = (
   block,
   inventory,
   plushieModifiers,
-  harvestFunction
+  harvestFunction,
+  stages
 ) => {
   const day = global.getDay(level);
   const data = plushieModifiers ? target : target.persistentData;
@@ -170,7 +178,7 @@ global.handleSpecialHarvest = (
       if (definition.animal.equals(type)) {
         definition.forages.forEach((forage) => {
           resolvedCount = forage.countMult;
-          if (forage.stage && player.stages.has(forage.stage.name)) {
+          if (forage.stage && global.isStagePresent(stages, forage.stage.name)) {
             resolvedCount = forage.stage.newCountMult;
           }
           if (forage.itemPool) {
@@ -204,7 +212,7 @@ global.handleSpecialHarvest = (
       }
     });
     if (
-      player.stages.has("coopmaster") &&
+      global.isStagePresent(stages, "coopmaster") &&
       (plushieModifiers
         ? global.coopMasterAnimals.includes(data.type)
         : global.checkEntityTag(target, "society:coopmaster_bird"))
@@ -229,7 +237,7 @@ global.handleSpecialHarvest = (
         }
       );
     }
-    if (data.bff && player.stages.has("bff")) {
+    if (data.bff && global.isStagePresent(stages, "bff")) {
       harvestFunction(
         data,
         day,
@@ -250,7 +258,7 @@ global.handleSpecialHarvest = (
         }
       );
     }
-    if (!player.isFake() && !player.stages.has("animal_fancy")) {
+    if (player && !player.isFake() && !global.isStagePresent(stages, "animal_fancy")) {
       harvestFunction(
         data,
         day,
@@ -271,7 +279,7 @@ global.handleSpecialHarvest = (
         }
       );
     }
-    if (player.stages.has("reaping_scythe")) {
+    if (global.isStagePresent(stages, "reaping_scythe")) {
       harvestFunction(
         data,
         day,
@@ -323,7 +331,12 @@ global.handleSpecialHarvest = (
   }
 };
 
-global.getMagicShearsOutput = (level, target, player, plushieModifiers) => {
+/**
+ * @param {Internal.Player|null} player
+ * player.stages, or auto grabber NBT stages, or null for mana milker
+ * @param {Internal.Stages|Internal.CompoundTag|null} stages
+ */
+global.getMagicShearsOutput = (level, target, player, plushieModifiers, stages) => {
   const day = global.getDay(level);
   const data = plushieModifiers ? target : target.persistentData;
   const ageLastMagicHarvested = data.getInt("ageLastMagicHarvested");
@@ -375,7 +388,7 @@ global.getMagicShearsOutput = (level, target, player, plushieModifiers) => {
         );
       }
     }
-    if (player.stages.has("mana_hand")) {
+    if (global.isStagePresent(stages, "mana_hand")) {
       let dropItem;
       for (let i = 0; i < droppedLoot.length; i++) {
         dropItem = droppedLoot[i];
@@ -392,7 +405,7 @@ global.getMagicShearsOutput = (level, target, player, plushieModifiers) => {
     for (let i = 0; i < droppedLoot.length; i++) {
       newLoot.push(droppedLoot[i]);
     }
-    if (player.stages.has("heretic")) {
+    if (global.isStagePresent(stages, "heretic")) {
       newLoot.push(Item.of("3x society:sparkstone"));
       if (!plushieModifiers) {
         target.attack(2);
@@ -427,11 +440,18 @@ const getNearbyBlocks = (level, target, radius, tag) => {
 };
 
 
+/**
+ * @param {Internal.Player|null} player
+ */
 global.getOrFetchMood = (level, target, day, player, debugMood, disregardPet) => {
   if (global.checkEntityTag(target, "society:pet_animal")) return 256;
   const data = target.persistentData;
   let moodDebuffs = 0;
   let moodImpactModifier = getMoodImpactModifier(target);
+  if (!player && debugMood) {
+    console.log("getOrFetchMood: cannot debug mood because player is falsey!");
+    debugMood = false;
+  }
   if (moodImpactModifier > 1 && debugMood) player.tell(Text.translatable("society.husbandry.mood.breed_impact", moodImpactModifier).gold());
   if (!disregardPet && global.compareDay(day, data.getInt("ageLastPet"), 1)) {
     moodDebuffs += 96;
@@ -645,7 +665,8 @@ global.executePlushieHusbandry = (
       player,
       day,
       false,
-      plushieMods
+      plushieMods,
+      null,
     );
     if (milkItem !== -1) {
       let milk = level.createEntity("minecraft:item");
@@ -691,7 +712,8 @@ global.executePlushieHusbandry = (
     block,
     undefined,
     plushieMods,
-    specialHarvestFunction
+    specialHarvestFunction,
+    player.stages,
   );
   if (!plushieMods.resetDay) {
     nbt.merge({
@@ -709,7 +731,8 @@ global.executePlushieHusbandry = (
       level,
       animal,
       player,
-      plushieMods
+      plushieMods,
+      player.stages,
     );
     if (droppedLoot !== -1) {
       server.runCommandSilent(

--- a/kubejs/startup_scripts/globalAnimalHandlers.js
+++ b/kubejs/startup_scripts/globalAnimalHandlers.js
@@ -92,8 +92,8 @@ const canMilk = (data, target, day, plushieModifiers) => {
 
 /**
  * @param {Internal.Player|null} player
- * player.stages, or auto-grabber NBT stages, or null for mana milker
- * @param {Internal.Stages|Internal.CompoundTag|null} stages 
+ * player.stages, or auto-grabber NBT stages, or empty stages for mana milker
+ * @param {Internal.Stages|SocietyStages} stages 
  */
 global.getMilk = (
   level,
@@ -115,7 +115,7 @@ global.getMilk = (
   } else {
     affection = data.getInt("affection") || 0;
     mood = global.getOrFetchMood(level, target, day, player);
-    affectionIncrease = global.isStagePresent(stages, "animal_whisperer") || data.bribed ? 10 : 5;
+    affectionIncrease = stages.has("animal_whisperer") || data.bribed ? 10 : 5;
   }
   let hearts = Math.floor(affection / 100);
 
@@ -138,7 +138,7 @@ global.getMilk = (
       }
     }
     return Item.of(
-      `${(global.isStagePresent(stages, "shepherd") ? 2 : 1) *
+      `${(stages.has("shepherd") ? 2 : 1) *
       crackerBonus *
       (plushieDoubleDrops ? 2 : 1)
       }x ${milkId}`,
@@ -150,7 +150,7 @@ global.getMilk = (
 
 /**
  * @param {Internal.Player|null} player
- * @param {Internal.Stages|Internal.CompoundTag} stages player.stages or auto-grabber NBT stages
+ * @param {Internal.Stages|SocietyStages} stages player.stages or auto-grabber NBT stages
  */
 global.handleSpecialHarvest = (
   level,
@@ -178,7 +178,7 @@ global.handleSpecialHarvest = (
       if (definition.animal.equals(type)) {
         definition.forages.forEach((forage) => {
           resolvedCount = forage.countMult;
-          if (forage.stage && global.isStagePresent(stages, forage.stage.name)) {
+          if (forage.stage && stages.has(forage.stage.name)) {
             resolvedCount = forage.stage.newCountMult;
           }
           if (forage.itemPool) {
@@ -212,7 +212,7 @@ global.handleSpecialHarvest = (
       }
     });
     if (
-      global.isStagePresent(stages, "coopmaster") &&
+      stages.has("coopmaster") &&
       (plushieModifiers
         ? global.coopMasterAnimals.includes(data.type)
         : global.checkEntityTag(target, "society:coopmaster_bird"))
@@ -237,7 +237,7 @@ global.handleSpecialHarvest = (
         }
       );
     }
-    if (data.bff && global.isStagePresent(stages, "bff")) {
+    if (data.bff && stages.has("bff")) {
       harvestFunction(
         data,
         day,
@@ -258,7 +258,7 @@ global.handleSpecialHarvest = (
         }
       );
     }
-    if (player && !player.isFake() && !global.isStagePresent(stages, "animal_fancy")) {
+    if (player && !player.isFake() && !stages.has("animal_fancy")) {
       harvestFunction(
         data,
         day,
@@ -279,7 +279,7 @@ global.handleSpecialHarvest = (
         }
       );
     }
-    if (global.isStagePresent(stages, "reaping_scythe")) {
+    if (stages.has("reaping_scythe")) {
       harvestFunction(
         data,
         day,
@@ -333,8 +333,8 @@ global.handleSpecialHarvest = (
 
 /**
  * @param {Internal.Player|null} player
- * player.stages, or auto grabber NBT stages, or null for mana milker
- * @param {Internal.Stages|Internal.CompoundTag|null} stages
+ * player.stages, or auto grabber NBT stages, or empty stages for mana milker
+ * @param {Internal.Stages|SocietyStages} stages
  */
 global.getMagicShearsOutput = (level, target, player, plushieModifiers, stages) => {
   const day = global.getDay(level);
@@ -388,7 +388,7 @@ global.getMagicShearsOutput = (level, target, player, plushieModifiers, stages) 
         );
       }
     }
-    if (global.isStagePresent(stages, "mana_hand")) {
+    if (stages.has("mana_hand")) {
       let dropItem;
       for (let i = 0; i < droppedLoot.length; i++) {
         dropItem = droppedLoot[i];
@@ -405,7 +405,7 @@ global.getMagicShearsOutput = (level, target, player, plushieModifiers, stages) 
     for (let i = 0; i < droppedLoot.length; i++) {
       newLoot.push(droppedLoot[i]);
     }
-    if (global.isStagePresent(stages, "heretic")) {
+    if (stages.has("heretic")) {
       newLoot.push(Item.of("3x society:sparkstone"));
       if (!plushieModifiers) {
         target.attack(2);
@@ -666,7 +666,7 @@ global.executePlushieHusbandry = (
       day,
       false,
       plushieMods,
-      null,
+      global.NO_STAGES,
     );
     if (milkItem !== -1) {
       let milk = level.createEntity("minecraft:item");

--- a/kubejs/startup_scripts/globalAnimalHandlers.js
+++ b/kubejs/startup_scripts/globalAnimalHandlers.js
@@ -666,7 +666,7 @@ global.executePlushieHusbandry = (
       day,
       false,
       plushieMods,
-      global.NO_STAGES,
+      player.stages,
     );
     if (milkItem !== -1) {
       let milk = level.createEntity("minecraft:item");

--- a/kubejs/startup_scripts/globalFish.js
+++ b/kubejs/startup_scripts/globalFish.js
@@ -225,7 +225,7 @@ global.getPondProperties = (block) => {
 
 /**
  * @param {Internal.Player|null} player
- * @param {Internal.Stages|Internal.CompoundTag} stages player.stages or fish pond basket NBT stages
+ * @param {Internal.Stages|SocietyStages} stages stages player.stages or fish pond basket NBT stages
  */
 global.handleFishHarvest = (block, player, server, basket, stages) => {
   const { facing, valid, upgraded, quest } = global.getPondProperties(block);
@@ -234,11 +234,11 @@ global.handleFishHarvest = (block, player, server, basket, stages) => {
   const fish = global.fishPondDefinitions.get(type);
   let additionalMaxRoe = 0;
   let harvestOutputs = [];
-  if (Math.random() < 0.01 && !global.isStagePresent(stages, "bullfish_jobs")) {
+  if (Math.random() < 0.01 && !stages.has("bullfish_jobs")) {
     harvestOutputs.push("society:bullfish_jobs");
   }
-  if (global.isStagePresent(stages, "caper_catcher")) additionalMaxRoe += 3;
-  if (global.isStagePresent(stages, "caviar_catcher")) additionalMaxRoe += 2;
+  if (stages.has("caper_catcher")) additionalMaxRoe += 3;
+  if (stages.has("caviar_catcher")) additionalMaxRoe += 2;
   const fishRoe = global.getRoe(type);
   const calculateRoe = rnd(
     Math.floor(population / 4),
@@ -252,7 +252,7 @@ global.handleFishHarvest = (block, player, server, basket, stages) => {
       fishPondRoll = Math.random();
       let rewardChance = reward.chance;
       if (upgraded == "true") rewardChance *= 2;
-      if (global.isStagePresent(stages, "scum_collector")) rewardChance *= 2;
+      if (stages.has("scum_collector")) rewardChance *= 2;
       if (population >= reward.minPopulation && fishPondRoll <= rewardChance) {
         // Rewards scale to amount of fish population relative to when reward starts spawning
         let calculateCount = Math.floor(
@@ -296,7 +296,7 @@ global.handleFishHarvest = (block, player, server, basket, stages) => {
 };
 
 /**
- * @param {Internal.Stages|Internal.CompoundTag} stages player.stages or fish pond basket NBT stages
+ * @param {Internal.Stages|SocietyStages} stages
  */
 global.handleFishExtraction = (block, player, server, stages) => {
   let nbt = block.getEntityData();
@@ -304,12 +304,12 @@ global.handleFishExtraction = (block, player, server, stages) => {
   let naturalPopulation = population - non_native_fish;
   let result;
   let resultCount =
-    global.isStagePresent(stages, "mitosis") && naturalPopulation > 0 ? 2 : 1;
+    stages.has("mitosis") && naturalPopulation > 0 ? 2 : 1;
   let quality = 0;
-  if (global.isStagePresent(stages, "bullfish_jobs") && Number(naturalPopulation) > 3) {
+  if (stages.has("bullfish_jobs") && Number(naturalPopulation) > 3) {
     quality = Math.floor((Number(population) - 3) / 2);
   }
-  if (global.isStagePresent(stages, "hot_hands") && naturalPopulation > 0) {
+  if (stages.has("hot_hands") && naturalPopulation > 0) {
     server.runCommandSilent(
       `playsound minecraft:block.lava.extinguish block @a ${block.x} ${block.y} ${block.z}`,
     );

--- a/kubejs/startup_scripts/globalFish.js
+++ b/kubejs/startup_scripts/globalFish.js
@@ -223,18 +223,22 @@ global.getPondProperties = (block) => {
   };
 };
 
-global.handleFishHarvest = (block, player, server, basket) => {
+/**
+ * @param {Internal.Player|null} player
+ * @param {Internal.Stages|Internal.CompoundTag} stages player.stages or fish pond basket NBT stages
+ */
+global.handleFishHarvest = (block, player, server, basket, stages) => {
   const { facing, valid, upgraded, quest } = global.getPondProperties(block);
   let nbt = block.getEntityData();
   const { quest_id, type, population, max_population } = nbt.data;
   const fish = global.fishPondDefinitions.get(type);
   let additionalMaxRoe = 0;
   let harvestOutputs = [];
-  if (Math.random() < 0.01 && !player.stages.has("bullfish_jobs")) {
+  if (Math.random() < 0.01 && !global.isStagePresent(stages, "bullfish_jobs")) {
     harvestOutputs.push("society:bullfish_jobs");
   }
-  if (player.stages.has("caper_catcher")) additionalMaxRoe += 3;
-  if (player.stages.has("caviar_catcher")) additionalMaxRoe += 2;
+  if (global.isStagePresent(stages, "caper_catcher")) additionalMaxRoe += 3;
+  if (global.isStagePresent(stages, "caviar_catcher")) additionalMaxRoe += 2;
   const fishRoe = global.getRoe(type);
   const calculateRoe = rnd(
     Math.floor(population / 4),
@@ -248,7 +252,7 @@ global.handleFishHarvest = (block, player, server, basket) => {
       fishPondRoll = Math.random();
       let rewardChance = reward.chance;
       if (upgraded == "true") rewardChance *= 2;
-      if (player.stages.has("scum_collector")) rewardChance *= 2;
+      if (global.isStagePresent(stages, "scum_collector")) rewardChance *= 2;
       if (population >= reward.minPopulation && fishPondRoll <= rewardChance) {
         // Rewards scale to amount of fish population relative to when reward starts spawning
         let calculateCount = Math.floor(
@@ -291,18 +295,21 @@ global.handleFishHarvest = (block, player, server, basket) => {
   });
 };
 
-global.handleFishExtraction = (block, player, server) => {
+/**
+ * @param {Internal.Stages|Internal.CompoundTag} stages player.stages or fish pond basket NBT stages
+ */
+global.handleFishExtraction = (block, player, server, stages) => {
   let nbt = block.getEntityData();
   const { type, population, non_native_fish } = nbt.data;
   let naturalPopulation = population - non_native_fish;
   let result;
   let resultCount =
-    player.stages.has("mitosis") && naturalPopulation > 0 ? 2 : 1;
+    global.isStagePresent(stages, "mitosis") && naturalPopulation > 0 ? 2 : 1;
   let quality = 0;
-  if (player.stages.has("bullfish_jobs") && Number(naturalPopulation) > 3) {
+  if (global.isStagePresent(stages, "bullfish_jobs") && Number(naturalPopulation) > 3) {
     quality = Math.floor((Number(population) - 3) / 2);
   }
-  if (player.stages.has("hot_hands") && naturalPopulation > 0) {
+  if (global.isStagePresent(stages, "hot_hands") && naturalPopulation > 0) {
     server.runCommandSilent(
       `playsound minecraft:block.lava.extinguish block @a ${block.x} ${block.y} ${block.z}`,
     );

--- a/kubejs/startup_scripts/globalMachineOwnerUtils.js
+++ b/kubejs/startup_scripts/globalMachineOwnerUtils.js
@@ -1,15 +1,30 @@
 /**
- * @param {Internal.Stages|Internal.CompoundTag|null} stages
- * @param {string} stage
+ * wrapper so that arbitrary stage data can be read using the has() method same as player.stages
+ * @param {string[]} stages
+ * @return {object}
  */
-global.isStagePresent = (stages, stage) => {
-  if (stages === null) {
-    return false;
-  }
-  try {
-    return stages.has(stage);
-  } catch (e) {}
-  return stages.contains(stage);
+function SocietyStages(stages) {
+  return {
+    value: stages,
+    has: function (x) {
+      return this.value.includes(x);
+    },
+  };
+}
+
+global.NO_STAGES = SocietyStages([]);
+
+const TAG_STRING = Java.loadClass("net.minecraft.nbt.Tag").TAG_STRING;
+
+/**
+ * reads stages set in block entity NBT data by global.cacheOwner()
+ * @param {Internal.BlockEntityJS} blockEntity
+ * @return {SocietyStages}
+ */
+global.getBlockEntityStages = (blockEntity) => {
+  return SocietyStages(
+    blockEntity.data.getList("stages", TAG_STRING).toArray().map((x) => x.toString())
+  );
 }
 
 /**

--- a/kubejs/startup_scripts/globalMachineOwnerUtils.js
+++ b/kubejs/startup_scripts/globalMachineOwnerUtils.js
@@ -1,0 +1,66 @@
+/**
+ * @param {Internal.Stages|Internal.CompoundTag|null} stages
+ * @param {string} stage
+ */
+global.isStagePresent = (stages, stage) => {
+  if (stages === null) {
+    return false;
+  }
+  try {
+    return stages.has(stage);
+  } catch (e) {}
+  return stages.contains(stage);
+}
+
+/**
+ * cache the stages of a block entity's owner in the block entity's NBT data
+ * cache the existence of the block entity's owner's attributes, regardless of attribute value
+ * if the owner is online, that player is returned, else null is returned
+ * if nothing has ever been cached before, and the owner is not online, stages=[] attributes=[]
+ * @param {Internal.BlockEntityJS} entity
+ * @param {string[]|null|undefined} stagesToFind
+ * @param {string[]|null|undefined} attributesToFind
+ * @return {Internal.Player|null} owner
+ */
+global.cacheOwner = (entity, stagesToFind, attributesToFind) => {
+  const { level, block } = entity;
+  let binPlayer = null;
+  level.getServer().players.forEach((p) => {
+    if (p.getUuid().toString() === block.getEntityData().data.owner) {
+      binPlayer = p; 
+    }
+  });
+  let nbt = block.getEntityData();
+  if (binPlayer) {
+    if (attributesToFind) {
+      let newAttributes = [];
+      attributesToFind.forEach((attr) => {
+        newAttributes.push({
+          Base: Number(
+            binPlayer.nbt.Attributes.filter((obj) => {
+              return obj.Name === attr;
+            })[0]?.Base
+          ),
+          Name: attr,
+        });
+      });
+      nbt.data.attributes = newAttributes;
+    }
+    if (stagesToFind) {
+      let stages = [];
+      stagesToFind.forEach((stage) => {
+        if (binPlayer.stages.has(stage)) stages.push(stage);
+      });
+      nbt.data.stages = stages;
+    }
+  } else {
+    if ((attributesToFind !== null) && !nbt.data.contains("attributes")) {
+      nbt.data.attributes = [];
+    }
+    if ((stagesToFind !== null) && !nbt.data.contains("stages")) {
+      nbt.data.stages = [];
+    }
+  }
+  global.setBlockEntityData(block, nbt);
+  return binPlayer;
+};

--- a/kubejs/startup_scripts/globalShippingBinHandlers.js
+++ b/kubejs/startup_scripts/globalShippingBinHandlers.js
@@ -368,7 +368,6 @@ global.processValueOutput = (
 };
 
 global.cacheShippingBin = (entity) => {
-  const { level, block } = entity;
   const attributeMapping = [
     "shippingbin:crop_sell_multiplier",
     "shippingbin:wood_sell_multiplier",
@@ -381,29 +380,5 @@ global.cacheShippingBin = (entity) => {
     "brine_and_punishment",
     "the_quality_of_the_earth",
   ];
-  let binPlayer;
-  level.getServer().players.forEach((p) => {
-    if (p.getUuid().toString() === block.getEntityData().data.owner) {
-      let newAttributes = [];
-      let stages = [];
-      attributeMapping.forEach((attr) => {
-        newAttributes.push({
-          Base: Number(
-            p.nbt.Attributes.filter((obj) => {
-              return obj.Name === attr;
-            })[0]?.Base
-          ),
-          Name: attr,
-        });
-      });
-      stagesToFind.forEach((stage) => {
-        if (p.stages.has(stage)) stages.push(stage);
-      });
-      let nbt = block.getEntityData();
-      nbt.merge({ data: { attributes: newAttributes, stages: stages } });
-      global.setBlockEntityData(block, nbt)
-      binPlayer = p;
-    }
-  });
-  return binPlayer;
+return global.cacheOwner(entity, stagesToFind, attributeMapping);
 };

--- a/kubejs/startup_scripts/globalShippingBinHandlers.js
+++ b/kubejs/startup_scripts/globalShippingBinHandlers.js
@@ -71,6 +71,10 @@ global.getAttributeMultiplier = (attributes, multiplier) => {
   );
 };
 
+/**
+ * TODO replace ListTag with SocietyStages, replace toString().includes() with has()
+ * @param {Internal.Stages|Internal.ListTag} stages 
+ */
 global.processShippingBinInventory = (
   inventory,
   inventorySlots,

--- a/kubejs/startup_scripts/powerfulMachines/artisanHopper.js
+++ b/kubejs/startup_scripts/powerfulMachines/artisanHopper.js
@@ -10,7 +10,7 @@ const artisanMachineCanHaveAdditionalOutput = [
 ];
 
 /** 
- * @param {Internal.CompoundTag} stages
+ * @param {Internal.Stages|SocietyStages} stages
  */
 global.handleAdditionalArtisanMachineOutputs = (
   level,
@@ -65,7 +65,7 @@ global.handleAdditionalArtisanMachineOutputs = (
       break;
     }
     case "society:aging_cask": {
-      if (stages.contains("aged_prize") && rnd5()) {
+      if (stages.has("aged_prize") && rnd5()) {
         global.insertBelow(level, block, "society:prize_ticket");
       }
       break;
@@ -86,7 +86,7 @@ global.handleAdditionalArtisanMachineOutputs = (
 };
 // TODO: make artisan hopper set tappers
 /**
- * @param {Internal.CompoundTag} stages
+ * @param {Internal.Stages|SocietyStages} stages
  */
 global.getArtisanMachineData = (player, block, upgraded, stages) => {
   let machineData = {
@@ -98,7 +98,7 @@ global.getArtisanMachineData = (player, block, upgraded, stages) => {
     soundType: "minecraft:ui.toast.in",
   };
   let rancherOutputCount;
-  if (stages.contains("rancher") && Math.random() <= 0.2) {
+  if (stages.has("rancher") && Math.random() <= 0.2) {
     rancherOutputCount = 2;
   }
   let machineNbt = block.getEntityData();
@@ -160,7 +160,7 @@ global.getArtisanMachineData = (player, block, upgraded, stages) => {
       };
       break;
     case "society:ancient_cask":
-      if (stages.contains("ancient_aging")) {
+      if (stages.has("ancient_aging")) {
         if (upgraded) {
           machineData = {
             recipes: global.ancientCaskRecipes,
@@ -245,7 +245,7 @@ global.getArtisanMachineData = (player, block, upgraded, stages) => {
         recipes: global.tapperRecipes,
         stageCount: 1,
         soundType: "vinery:cabinet_close",
-        outputMult: stages.contains("canadian_and_famous") ? 2 : 1,
+        outputMult: stages.has("canadian_and_famous") ? 2 : 1,
       };
       break;
     case "society:mushroom_log":
@@ -279,7 +279,7 @@ global.runArtisanHopper = (artisanHopper, artisanMachinePos, player, delay) => {
     const nbt = artisanMachine.getEntityData();
     if (!nbt || !nbt.data) return;
     const upgraded = artisanMachine.properties.get("upgraded") == "true";
-    const stages = artisanHopper.data.stages;
+    const stages = global.getBlockEntityStages(artisanHopper);
     const loadedData = global.getArtisanMachineData(
       player,
       artisanMachine,
@@ -391,7 +391,7 @@ global.runArtisanHopper = (artisanHopper, artisanMachinePos, player, delay) => {
             );
           }
           let sparkstoneSaveChance = 0;
-          if (stages.contains("slouching_towards_artistry")) {
+          if (stages.has("slouching_towards_artistry")) {
             sparkstoneSaveChance = Number(currentStage) * 0.05;
           }
           if (!recycleSparkstone && Math.random() > sparkstoneSaveChance) {

--- a/kubejs/startup_scripts/powerfulMachines/artisanHopper.js
+++ b/kubejs/startup_scripts/powerfulMachines/artisanHopper.js
@@ -9,6 +9,11 @@ const artisanMachineCanHaveAdditionalOutput = [
   "society:wine_keg"
 ];
 
+/** 
+ * @param {Internal.Level} level
+ * @param {Internal.BlockContainerJS} block
+ * @param {Internal.BlockContainerJS} artisanMachine
+ */
 global.handleAdditionalArtisanMachineOutputs = (
   level,
   block,
@@ -16,7 +21,7 @@ global.handleAdditionalArtisanMachineOutputs = (
   recipes,
   recipeId,
   upgraded,
-  stages
+  agedPrize
 ) => {
   switch (artisanMachine.id) {
     case "society:loom": {
@@ -62,7 +67,7 @@ global.handleAdditionalArtisanMachineOutputs = (
       break;
     }
     case "society:aging_cask": {
-      if (stages.has("aged_prize") && rnd5()) {
+      if (agedPrize && rnd5()) {
         global.insertBelow(level, block, "society:prize_ticket");
       }
       break;
@@ -81,8 +86,12 @@ global.handleAdditionalArtisanMachineOutputs = (
     }
   }
 };
+
 // TODO: make artisan hopper set tappers
-global.getArtisanMachineData = (player, block, upgraded, stages) => {
+/**
+ * @param {Internal.BlockContainerJS} block
+ */
+global.getArtisanMachineData = (block, upgraded, rancher, ancientAging, canadianAndFamous) => {
   let machineData = {
     recipes: [],
     stageCount: 0,
@@ -92,7 +101,7 @@ global.getArtisanMachineData = (player, block, upgraded, stages) => {
     soundType: "minecraft:ui.toast.in",
   };
   let rancherOutputCount;
-  if (player.stages.has("rancher") && Math.random() <= 0.2) {
+  if (rancher && Math.random() <= 0.2) {
     rancherOutputCount = 2;
   }
   let machineNbt = block.getEntityData();
@@ -154,7 +163,7 @@ global.getArtisanMachineData = (player, block, upgraded, stages) => {
       };
       break;
     case "society:ancient_cask":
-      if (stages.has("ancient_aging")) {
+      if (ancientAging) {
         if (upgraded) {
           machineData = {
             recipes: global.ancientCaskRecipes,
@@ -239,7 +248,7 @@ global.getArtisanMachineData = (player, block, upgraded, stages) => {
         recipes: global.tapperRecipes,
         stageCount: 1,
         soundType: "vinery:cabinet_close",
-        outputMult: stages.has("canadian_and_famous") ? 2 : 1,
+        outputMult: canadianAndFamous ? 2 : 1,
       };
       break;
     case "society:mushroom_log":
@@ -259,21 +268,28 @@ global.getArtisanMachineData = (player, block, upgraded, stages) => {
   return machineData;
 };
 
-global.runArtisanHopper = (tickEvent, artisanMachinePos, player, delay) => {
-  const { level, block, inventory } = tickEvent;
+/** 
+ * @param {Internal.BlockEntityJS} artisanHopperBlockEntity
+ * @param {BlockPos} artisanMachinePos
+ * @param {Internal.Player|null} player
+ */
+global.runArtisanHopper = (artisanHopperBlockEntity, artisanMachinePos, player, delay) => {
+  const { level, block, inventory } = artisanHopperBlockEntity;
   const server = level.server;
 
   server.scheduleInTicks(delay, () => {
     const artisanMachine = level.getBlock(artisanMachinePos);
     const { x, y, z } = artisanMachine;
     const nbt = artisanMachine.getEntityData();
+    const artisanHopperNbt = artisanHopperBlockEntity.getEntityData();
     if (!nbt || !nbt.data) return;
     const upgraded = artisanMachine.properties.get("upgraded") == "true";
     const loadedData = global.getArtisanMachineData(
-      player,
       artisanMachine,
       upgraded,
-      player.stages
+      artisanHopperNbt.getBoolean("rancher"),
+      artisanHopperNbt.getBoolean("ancient_aging"),
+      artisanHopperNbt.getBoolean("canadian_and_famous")
     );
     const season = global.getSeasonFromLevel(level);
     const chargingRodOutput = Item.of(
@@ -376,11 +392,11 @@ global.runArtisanHopper = (tickEvent, artisanMachinePos, player, delay) => {
               recipes,
               resolvedRecipeId,
               upgraded,
-              player.stages
+              artisanHopperNbt.getBoolean("aged_prize"),
             );
           }
           let sparkstoneSaveChance = 0;
-          if (player.stages.has("slouching_towards_artistry")) {
+          if (artisanHopperNbt.getBoolean("slouching_towards_artistry")) {
             sparkstoneSaveChance = Number(currentStage) * 0.05;
           }
           if (!recycleSparkstone && Math.random() > sparkstoneSaveChance) {
@@ -429,7 +445,9 @@ global.runArtisanHopper = (tickEvent, artisanMachinePos, player, delay) => {
       ) {
         let aboveBlockData = aboveBlock.getEntityData();
         if (aboveBlockData && aboveBlockData.toString().includes("filter_upgrade")) {
-          player.tell(Text.translatable("block.society.artisan_hopper.filter").red());
+          if (player) {
+            player.tell(Text.translatable("block.society.artisan_hopper.filter").red());
+          }
           return;
         }
         let slots = aboveBlock.inventory.getSlots();
@@ -500,33 +518,48 @@ global.runArtisanHopper = (tickEvent, artisanMachinePos, player, delay) => {
   });
 };
 
+/**
+ * @param {Internal.BlockEntityJS} entity
+ */
 global.artisanHopperScan = (entity, radius) => {
   const { block, level } = entity;
   const { x, y, z } = block;
-  let attachedPlayer;
+  let attachedPlayer = null;
   level.getServer().players.forEach((p) => {
     if (p.getUuid().toString() === block.getEntityData().data.owner) {
       attachedPlayer = p;
     }
   });
-  if (attachedPlayer) {
-    let scanBlock;
-    let scannedBlocks = 0;
-    for (let pos of BlockPos.betweenClosed(
-      new BlockPos(x - radius, y - radius, z - radius),
-      [x + radius, y + radius, z + radius]
-    )) {
-      if (!level.isLoaded(pos)) continue;
-      scanBlock = level.getBlock(pos);
-      if (scanBlock.hasTag("society:artisan_machine")) {
-        global.runArtisanHopper(
-          entity,
-          pos.immutable(),
-          attachedPlayer,
-          scannedBlocks * 5
-        );
-        scannedBlocks++;
-      }
+  const stagesToStore = [
+    "slouching_towards_artistry", "ancient_aging", "rancher", "aged_prize", "canadian_and_famous"
+  ];
+  let newData = {};
+  for (const stage of stagesToStore) {
+    if (attachedPlayer) {
+      newData[stage] = attachedPlayer.stages.has(stage);
+    } else if (!nbt.contains(stage)) {
+      newData[stage] = false;
+    }
+  }
+  if (Object.keys(newData).length > 0) {
+    global.setBlockEntityData(block, block.getEntityData().merge({ data: newData }));
+  }
+  let scanBlock;
+  let scannedBlocks = 0;
+  for (let pos of BlockPos.betweenClosed(
+    new BlockPos(x - radius, y - radius, z - radius),
+    [x + radius, y + radius, z + radius]
+  )) {
+    if (!level.isLoaded(pos)) continue;
+    scanBlock = level.getBlock(pos);
+    if (scanBlock.hasTag("society:artisan_machine")) {
+      global.runArtisanHopper(
+        entity,
+        pos.immutable(),
+        attachedPlayer,
+        scannedBlocks * 5
+      );
+      scannedBlocks++;
     }
   }
 };

--- a/kubejs/startup_scripts/powerfulMachines/artisanHopper.js
+++ b/kubejs/startup_scripts/powerfulMachines/artisanHopper.js
@@ -10,9 +10,7 @@ const artisanMachineCanHaveAdditionalOutput = [
 ];
 
 /** 
- * @param {Internal.Level} level
- * @param {Internal.BlockContainerJS} block
- * @param {Internal.BlockContainerJS} artisanMachine
+ * @param {Internal.CompoundTag} stages
  */
 global.handleAdditionalArtisanMachineOutputs = (
   level,
@@ -21,7 +19,7 @@ global.handleAdditionalArtisanMachineOutputs = (
   recipes,
   recipeId,
   upgraded,
-  agedPrize
+  stages
 ) => {
   switch (artisanMachine.id) {
     case "society:loom": {
@@ -67,7 +65,7 @@ global.handleAdditionalArtisanMachineOutputs = (
       break;
     }
     case "society:aging_cask": {
-      if (agedPrize && rnd5()) {
+      if (stages.contains("aged_prize") && rnd5()) {
         global.insertBelow(level, block, "society:prize_ticket");
       }
       break;
@@ -86,12 +84,11 @@ global.handleAdditionalArtisanMachineOutputs = (
     }
   }
 };
-
 // TODO: make artisan hopper set tappers
 /**
- * @param {Internal.BlockContainerJS} block
+ * @param {Internal.CompoundTag} stages
  */
-global.getArtisanMachineData = (block, upgraded, rancher, ancientAging, canadianAndFamous) => {
+global.getArtisanMachineData = (player, block, upgraded, stages) => {
   let machineData = {
     recipes: [],
     stageCount: 0,
@@ -101,7 +98,7 @@ global.getArtisanMachineData = (block, upgraded, rancher, ancientAging, canadian
     soundType: "minecraft:ui.toast.in",
   };
   let rancherOutputCount;
-  if (rancher && Math.random() <= 0.2) {
+  if (stages.contains("rancher") && Math.random() <= 0.2) {
     rancherOutputCount = 2;
   }
   let machineNbt = block.getEntityData();
@@ -163,7 +160,7 @@ global.getArtisanMachineData = (block, upgraded, rancher, ancientAging, canadian
       };
       break;
     case "society:ancient_cask":
-      if (ancientAging) {
+      if (stages.contains("ancient_aging")) {
         if (upgraded) {
           machineData = {
             recipes: global.ancientCaskRecipes,
@@ -248,7 +245,7 @@ global.getArtisanMachineData = (block, upgraded, rancher, ancientAging, canadian
         recipes: global.tapperRecipes,
         stageCount: 1,
         soundType: "vinery:cabinet_close",
-        outputMult: canadianAndFamous ? 2 : 1,
+        outputMult: stages.contains("canadian_and_famous") ? 2 : 1,
       };
       break;
     case "society:mushroom_log":
@@ -269,27 +266,25 @@ global.getArtisanMachineData = (block, upgraded, rancher, ancientAging, canadian
 };
 
 /** 
- * @param {Internal.BlockEntityJS} artisanHopperBlockEntity
- * @param {BlockPos} artisanMachinePos
+ * @param {Internal.BlockEntityJS} artisanHopper
  * @param {Internal.Player|null} player
  */
-global.runArtisanHopper = (artisanHopperBlockEntity, artisanMachinePos, player, delay) => {
-  const { level, block, inventory } = artisanHopperBlockEntity;
+global.runArtisanHopper = (artisanHopper, artisanMachinePos, player, delay) => {
+  const { level, block, inventory } = artisanHopper;
   const server = level.server;
 
   server.scheduleInTicks(delay, () => {
     const artisanMachine = level.getBlock(artisanMachinePos);
     const { x, y, z } = artisanMachine;
     const nbt = artisanMachine.getEntityData();
-    const artisanHopperNbt = artisanHopperBlockEntity.getEntityData();
     if (!nbt || !nbt.data) return;
     const upgraded = artisanMachine.properties.get("upgraded") == "true";
+    const stages = artisanHopper.data.stages;
     const loadedData = global.getArtisanMachineData(
+      player,
       artisanMachine,
       upgraded,
-      artisanHopperNbt.getBoolean("rancher"),
-      artisanHopperNbt.getBoolean("ancient_aging"),
-      artisanHopperNbt.getBoolean("canadian_and_famous")
+      stages,
     );
     const season = global.getSeasonFromLevel(level);
     const chargingRodOutput = Item.of(
@@ -392,11 +387,11 @@ global.runArtisanHopper = (artisanHopperBlockEntity, artisanMachinePos, player, 
               recipes,
               resolvedRecipeId,
               upgraded,
-              artisanHopperNbt.getBoolean("aged_prize"),
+              stages
             );
           }
           let sparkstoneSaveChance = 0;
-          if (artisanHopperNbt.getBoolean("slouching_towards_artistry")) {
+          if (stages.contains("slouching_towards_artistry")) {
             sparkstoneSaveChance = Number(currentStage) * 0.05;
           }
           if (!recycleSparkstone && Math.random() > sparkstoneSaveChance) {
@@ -524,26 +519,9 @@ global.runArtisanHopper = (artisanHopperBlockEntity, artisanMachinePos, player, 
 global.artisanHopperScan = (entity, radius) => {
   const { block, level } = entity;
   const { x, y, z } = block;
-  let attachedPlayer = null;
-  level.getServer().players.forEach((p) => {
-    if (p.getUuid().toString() === block.getEntityData().data.owner) {
-      attachedPlayer = p;
-    }
-  });
-  const stagesToStore = [
+  const attachedPlayer = global.cacheOwner(entity, [
     "slouching_towards_artistry", "ancient_aging", "rancher", "aged_prize", "canadian_and_famous"
-  ];
-  let newData = {};
-  for (const stage of stagesToStore) {
-    if (attachedPlayer) {
-      newData[stage] = attachedPlayer.stages.has(stage);
-    } else if (!nbt.contains(stage)) {
-      newData[stage] = false;
-    }
-  }
-  if (Object.keys(newData).length > 0) {
-    global.setBlockEntityData(block, block.getEntityData().merge({ data: newData }));
-  }
+  ]);
   let scanBlock;
   let scannedBlocks = 0;
   for (let pos of BlockPos.betweenClosed(
@@ -596,8 +574,8 @@ StartupEvents.registry("block", (event) => {
       blockInfo.initialData({ owner: "-1" });
       blockInfo.serverTick(600, 0, (entity) => {
         global.artisanHopperScan(entity, 3);
-      }),
-        blockInfo.rightClickOpensInventory();
+      });
+      blockInfo.rightClickOpensInventory();
       blockInfo.attachCapability(
         CapabilityBuilder.ITEM.blockEntity()
           .insertItem((blockEntity, slot, stack, simulate) =>
@@ -649,8 +627,8 @@ StartupEvents.registry("block", (event) => {
       blockInfo.initialData({ owner: "-1" });
       blockInfo.serverTick(600, 0, (entity) => {
         global.artisanHopperScan(entity, 1);
-      }),
-        blockInfo.rightClickOpensInventory();
+      });
+      blockInfo.rightClickOpensInventory();
       blockInfo.attachCapability(
         CapabilityBuilder.ITEM.blockEntity()
           .insertItem((blockEntity, slot, stack, simulate) =>

--- a/kubejs/startup_scripts/powerfulMachines/autoGrabber.js
+++ b/kubejs/startup_scripts/powerfulMachines/autoGrabber.js
@@ -95,7 +95,7 @@ global.autoGrabAnimal = (autoGrabber, player, animal, plushieModifiers) => {
   } else {
     data = animal.persistentData;
   }
-  const stages = autoGrabber.data.stages;
+  const stages = global.getBlockEntityStages(autoGrabber);
   const day = global.getDay(level);
   let mood;
   let hungry;

--- a/kubejs/startup_scripts/powerfulMachines/autoGrabber.js
+++ b/kubejs/startup_scripts/powerfulMachines/autoGrabber.js
@@ -80,8 +80,12 @@ const handleAutoGrabSpecialItem = (
   }
 };
 
-global.autoGrabAnimal = (entity, player, animal, plushieModifiers) => {
-  const { inventory, block, level } = entity;
+/**
+ * @param {Internal.BlockEntityJS} autoGrabber
+ * @param {Internal.Player|null} player
+ */
+global.autoGrabAnimal = (autoGrabber, player, animal, plushieModifiers) => {
+  const { inventory, block, level } = autoGrabber;
   let recycleSparkstone;
   let data;
   let nbt;
@@ -91,6 +95,7 @@ global.autoGrabAnimal = (entity, player, animal, plushieModifiers) => {
   } else {
     data = animal.persistentData;
   }
+  const stages = autoGrabber.data.stages;
   const day = global.getDay(level);
   let mood;
   let hungry;
@@ -117,7 +122,8 @@ global.autoGrabAnimal = (entity, player, animal, plushieModifiers) => {
         player,
         day,
         false,
-        plushieModifiers
+        plushieModifiers,
+        stages,
       );
       if (milkItem !== -1) {
         let insertedMilk = global.insertBelow(level, block, milkItem) == 1;
@@ -160,11 +166,12 @@ global.autoGrabAnimal = (entity, player, animal, plushieModifiers) => {
         level,
         plushieModifiers ? data : animal,
         player,
-        player.server,
+        animal.server,
         block,
         inventory,
         plushieModifiers,
-        handleAutoGrabSpecialItem
+        handleAutoGrabSpecialItem,
+        stages,
       );
       if (plushieModifiers && !plushieModifiers.resetDay) {
         nbt.merge({
@@ -185,7 +192,8 @@ global.autoGrabAnimal = (entity, player, animal, plushieModifiers) => {
         level,
         plushieModifiers ? data : animal,
         player,
-        plushieModifiers
+        plushieModifiers,
+        stages,
       );
       if (droppedLoot !== -1) {
         level.server.runCommandSilent(
@@ -208,43 +216,39 @@ global.autoGrabAnimal = (entity, player, animal, plushieModifiers) => {
   }
 };
 
-global.runAutoGrabber = (entity) => {
+/**
+ * @param {Internal.BlockEntityJS} entity
+ * @param {Internal.Player|null} attachedPlayer
+ */
+global.runAutoGrabber = (entity, attachedPlayer) => {
   const { block, level } = entity;
   let radius = 5;
-  let attachedPlayer;
   let nearbyFarmAnimals;
   nearbyFarmAnimals = level
     .getEntitiesWithin(AABB.ofBlock(block).inflate(radius))
     .filter((entity) =>
       global.checkEntityTag(entity, "society:husbandry_animal")
     );
-  level.getServer().players.forEach((p) => {
-    if (p.getUuid().toString() === block.getEntityData().data.owner) {
-      attachedPlayer = p;
-    }
+  nearbyFarmAnimals.forEach((animal) => {
+    global.autoGrabAnimal(entity, attachedPlayer, animal);
   });
-  if (attachedPlayer) {
-    nearbyFarmAnimals.forEach((animal) => {
-      global.autoGrabAnimal(entity, attachedPlayer, animal);
-    });
-    let { x, y, z } = block;
-    let scanBlock;
-    for (let pos of BlockPos.betweenClosed(
-      new BlockPos(x - radius, y - radius, z - radius),
-      [x + radius, y + radius, z + radius]
-    )) {
-      if (!level.isLoaded(pos)) continue;
-      scanBlock = level.getBlock(pos);
-      if (scanBlock.hasTag("society:plushies")) {
-        let nbt = scanBlock.getEntityData();
-        if (nbt.data.animal) {
-          global.autoGrabAnimal(
-            entity,
-            attachedPlayer,
-            scanBlock,
-            global.getPlushieModifiers(level, nbt.data, scanBlock)
-          );
-        }
+  let { x, y, z } = block;
+  let scanBlock;
+  for (let pos of BlockPos.betweenClosed(
+    new BlockPos(x - radius, y - radius, z - radius),
+    [x + radius, y + radius, z + radius]
+  )) {
+    if (!level.isLoaded(pos)) continue;
+    scanBlock = level.getBlock(pos);
+    if (scanBlock.hasTag("society:plushies")) {
+      let nbt = scanBlock.getEntityData();
+      if (nbt.data.animal) {
+        global.autoGrabAnimal(
+          entity,
+          attachedPlayer,
+          scanBlock,
+          global.getPlushieModifiers(level, nbt.data, scanBlock)
+        );
       }
     }
   }
@@ -296,7 +300,17 @@ StartupEvents.registry("block", (event) => {
       blockInfo.inventory(9, 2);
       blockInfo.initialData({ owner: "-1" });
       blockInfo.serverTick(600, 0, (entity) => {
-        global.runAutoGrabber(entity);
+        const attachedPlayer = global.cacheOwner(entity, [
+          "animal_fancy",
+          "animal_whisperer",
+          "bff",
+          "coopmaster",
+          "heretic",
+          "mana_hand",
+          "reaping_scythe",
+          "shepherd",
+        ]);
+        global.runAutoGrabber(entity, attachedPlayer);
       }),
         blockInfo.rightClickOpensInventory();
       blockInfo.attachCapability(

--- a/kubejs/startup_scripts/powerfulMachines/fishPondBasket.js
+++ b/kubejs/startup_scripts/powerfulMachines/fishPondBasket.js
@@ -1,7 +1,12 @@
 console.info("[SOCIETY] artisanHopper.js loaded");
 
-global.runFishPondBasket = (tickEvent, fishPondPos, player) => {
-  const { level, block, inventory } = tickEvent;
+/**
+ * @param {Internal.BlockEntityJS} fishPondBasket
+ * @param {Internal.Player|null} player
+ */
+global.runFishPondBasket = (fishPondBasket, fishPondPos, player) => {
+  const { level, block, inventory } = fishPondBasket;
+  const stages = fishPondBasket.data.stages;
   const server = level.server;
   const fishPond = level.getBlock(fishPondPos);
   const { x, y, z } = fishPond;
@@ -17,7 +22,7 @@ global.runFishPondBasket = (tickEvent, fishPondPos, player) => {
     global.inventoryBelowHasRoom(level, block, global.getRoe(type)) &&
     (recycleSparkstone || global.useInventoryItems(inventory, "society:sparkstone", 1) == 1)
   ) {
-    machineOutputs = global.handleFishHarvest(fishPond, player, server, true);
+    machineOutputs = global.handleFishHarvest(fishPond, player, server, true, stages);
 
     if (machineOutputs.length > 0) {
       machineOutputs.forEach((item) => {
@@ -42,7 +47,7 @@ global.runFishPondBasket = (tickEvent, fishPondPos, player) => {
     level.getBlock(block.pos).getProperties().get("upgraded") === "true" &&
     population > 0 && max_population === population
   ) {
-    let fishie = global.handleFishExtraction(fishPond, player, server);
+    let fishie = global.handleFishExtraction(fishPond, player, server, stages);
     recycleSparkstone = global.checkSparkstoneRecyclers(level, block);
     if (
       global.inventoryBelowHasRoom(level, block, fishie) &&
@@ -117,23 +122,23 @@ StartupEvents.registry("block", (event) => {
         const { block, level } = entity;
         const { x, y, z } = block;
         const radius = 1;
-        let attachedPlayer;
-        level.getServer().players.forEach((p) => {
-          if (p.getUuid().toString() === block.getEntityData().data.owner) {
-            attachedPlayer = p;
-          }
-        });
-        if (attachedPlayer) {
-          let scanBlock;
-          for (let pos of BlockPos.betweenClosed(
-            new BlockPos(x - radius, y - radius, z - radius),
-            [x + radius, y + radius, z + radius]
-          )) {
-            if (!level.isLoaded(pos)) continue;
-            scanBlock = level.getBlock(pos);
-            if (scanBlock.id === "society:fish_pond") {
-              global.runFishPondBasket(entity, pos.immutable(), attachedPlayer);
-            }
+        let attachedPlayer = global.cacheOwner(entity, [
+          "bullfish_jobs",
+          "caper_catcher",
+          "caviar_catcher",
+          "hot_hands",
+          "mitosis",
+          "scum_collector",
+        ]);
+        let scanBlock;
+        for (let pos of BlockPos.betweenClosed(
+          new BlockPos(x - radius, y - radius, z - radius),
+          [x + radius, y + radius, z + radius]
+        )) {
+          if (!level.isLoaded(pos)) continue;
+          scanBlock = level.getBlock(pos);
+          if (scanBlock.id === "society:fish_pond") {
+            global.runFishPondBasket(entity, pos.immutable(), attachedPlayer);
           }
         }
       }),

--- a/kubejs/startup_scripts/powerfulMachines/fishPondBasket.js
+++ b/kubejs/startup_scripts/powerfulMachines/fishPondBasket.js
@@ -6,7 +6,7 @@ console.info("[SOCIETY] artisanHopper.js loaded");
  */
 global.runFishPondBasket = (fishPondBasket, fishPondPos, player) => {
   const { level, block, inventory } = fishPondBasket;
-  const stages = fishPondBasket.data.stages;
+  const stages = global.getBlockEntityStages(fishPondBasket);
   const server = level.server;
   const fishPond = level.getBlock(fishPondPos);
   const { x, y, z } = fishPond;

--- a/kubejs/startup_scripts/powerfulMachines/manaMilker.js
+++ b/kubejs/startup_scripts/powerfulMachines/manaMilker.js
@@ -44,7 +44,7 @@ StartupEvents.registry("block", (event) => {
           let data = animal.persistentData;
           if (mana >= MANA_PER_MILK) {
             const day = global.getDay(level);
-            let milkItem = global.getMilk(level, animal, data, undefined, day);
+            let milkItem = global.getMilk(level, animal, data, null, day, null);
             if (milkItem !== -1) {
               let success = entity.inventory.insertItem(milkItem, false);
               if (success) {

--- a/kubejs/startup_scripts/powerfulMachines/manaMilker.js
+++ b/kubejs/startup_scripts/powerfulMachines/manaMilker.js
@@ -44,7 +44,9 @@ StartupEvents.registry("block", (event) => {
           let data = animal.persistentData;
           if (mana >= MANA_PER_MILK) {
             const day = global.getDay(level);
-            let milkItem = global.getMilk(level, animal, data, null, day, null);
+            let milkItem = global.getMilk(
+              level, animal, data, null, day, undefined, undefined, global.NO_STAGES
+            );
             if (milkItem !== -1) {
               let success = entity.inventory.insertItem(milkItem, false);
               if (success) {


### PR DESCRIPTION
~~This is a proof of concept for how artisan hoppers can be made to work while their owner is offline. It is not ready for production, I am just looking for feedback so I can tell whether I should continue working on this idea or drop it. If I was going to continue, I would consider doing the same for auto grabbers and fish ponds, since they also use the `attachedPlayer` pattern.~~

[discord thread: "Can I have artisan items and fish ponds run when i'm offline from my server?"](https://discord.com/channels/1322431115339894925/1501991404375769219)

<img width="986" height="386" alt="image" src="https://github.com/user-attachments/assets/b2017a57-1ebe-421f-8a68-aac5c0d2b28e" />

<!--
<img width="923" height="346" alt="image" src="https://github.com/user-attachments/assets/0ef7663d-d4be-4373-ab82-a7f62e240c4d" />
-->


## PR checklist
Check all that apply
- [x] I have read the [contribution guide](https://github.com/Chakyl/society-sunlit-valley?tab=readme-ov-file#contribution-guide)
- [ ] Bugfix, typos, documentation
- [ ] New content
- [x] Changes to existing content
- [ ] Translation
- [ ] Work in this PR contains AI generated text, images, or code

## Changelog
- Store certain player stages (rancher, ancient aging, ...) in NBT data of the artisan hoppers, auto grabbers, fish pond baskets
- Change the `player` argument in functions to be sometimes `null`
- Add the `stages` argument to functions
- Rename the `tickEvent` argument in functions to reflect the type
- Add JSDoc comments
- Allow artisan hoppers, auto grabbers, fish pond baskets to run while the owner is offline
