### PR TITLE
Fix Mana Sprinkler mana area (7x7 -> 5x5)

### DIFF
--- a/kubejs/startup_scripts/powerfulMachines/manaSprinkler.js
+++ b/kubejs/startup_scripts/powerfulMachines/manaSprinkler.js
@@ -75,7 +75,7 @@ StartupEvents.registry("block", (event) => {
     .model("society:block/kubejs/mana_sprinkler")
     .blockEntity((blockInfo) => {
       blockInfo.serverTick(20, 0, (entity) => {
-        global.manaSprinklerScan(entity, 3);
+        global.manaSprinklerScan(entity, 2);
       }),
         blockInfo.attachCapability(
           BotaniaCapabilityBuilder.MANA.blockEntity()


### PR DESCRIPTION
## PR checklist
Check all that apply
- [x] I have read the [contribution guide](https://github.com/Chakyl/society-sunlit-valley?tab=readme-ov-file#contribution-guide)
- [x] Bugfix, typos, documentation
- [ ] New content
- [x] Changes to existing content
- [ ] Translation
- [ ] Work in this PR contains AI generated text, images, or code

## Summary
Fixes #272 — the Mana Sprinkler supplies mana in a 7x7 area instead of the intended 5x5.

## Root cause
`manaSprinkler.js` scans for `society:mana_fruit_crop` using `global.manaSprinklerScan(entity, 3)`. The scan iterates from `x - radius` to `x + radius`, so a radius of `3` covers 7 blocks per axis (7x7). The block's own tooltip advertises `5x5`, and crop watering (handled separately by the `dew_drop_farmland_growth:sprinkler_tier_2` tag) already uses 5x5 — which is why only the mana area was oversized.

## Fix
Lower the mana scan radius from `3` to `2` (5 blocks per axis = 5x5), matching the tooltip and the watering area.

```diff
- global.manaSprinklerScan(entity, 3);
+ global.manaSprinklerScan(entity, 2);
```

## Testing
- Place a `society:mana_fruit_crop` 3 blocks away from the sprinkler: before the fix it received mana (7x7), after the fix it does not (only within 2 blocks / 5x5).
- Crop watering is unaffected (separate mechanic).

## Notes
- Targets `4.1.0`; the same radius is present on 4.0.9 (the reporter's version) — happy to retarget if you prefer another branch.