### PR TITLE
Add Petal Apothecary recipes for double mystical flowers

### DIFF
--- a/kubejs/server_scripts/recipes/addDoubleMysticalFlowerRecipes.js
+++ b/kubejs/server_scripts/recipes/addDoubleMysticalFlowerRecipes.js
@@ -1,0 +1,53 @@
+console.info("[SOCIETY] addDoubleMysticalFlowerRecipes.js loaded");
+
+// Botania's vanilla way of making tall (double) mystical flowers - planting a
+// petal and bonemealing it - is disabled in the pack (see
+// blockEvents/disableQuarkMysticalFlowers.js), so give players a Petal
+// Apothecary recipe instead. Costs 4 petals of a color for that color's double
+// flower: a double flower is worth two single flowers, so this stays balanced
+// even if a flower -> petal recipe is ever added (no infinite-petal loop).
+ServerEvents.recipes((e) => {
+  [
+    "white",
+    "orange",
+    "magenta",
+    "light_blue",
+    "yellow",
+    "lime",
+    "pink",
+    "gray",
+    "light_gray",
+    "cyan",
+    "purple",
+    "blue",
+    "brown",
+    "green",
+    "red",
+    "black",
+  ].forEach((color) => {
+    e.custom({
+      type: "botania:petal_apothecary",
+      ingredients: [
+        {
+          tag: `botania:petals/${color}`,
+        },
+        {
+          tag: `botania:petals/${color}`,
+        },
+        {
+          tag: `botania:petals/${color}`,
+        },
+        {
+          tag: `botania:petals/${color}`,
+        },
+      ],
+      output: {
+        item: `botania:${color}_double_flower`,
+        count: 1,
+      },
+      reagent: {
+        tag: "botania:seed_apothecary_reagent",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## PR checklist
Check all that apply
- [x] I have read the [contribution guide](https://github.com/Chakyl/society-sunlit-valley?tab=readme-ov-file#contribution-guide)
- [x] Bugfix, typos, documentation
- [x] New content
- [x] Changes to existing content
- [ ] Translation
- [ ] Work in this PR contains AI generated text, images, or code

## Summary
Closes #139 — adds a way to obtain the 16 double (tall) mystical flowers, which are currently unobtainable.

## Context
Botania's vanilla method (plant a petal, then bonemeal it) is disabled in the pack: `blockEvents/disableQuarkMysticalFlowers.js` cancels right-click on blocks tagged `botania:mystical_flowers`, which also kills the bonemeal -> double flower path. As a result the 16 `botania:<color>_double_flower` items have no in-game recipe.

## Change
New script `kubejs/server_scripts/recipes/addDoubleMysticalFlowerRecipes.js` registers one Petal Apothecary recipe per color:
- **4x `botania:petals/<color>` -> 1x `botania:<color>_double_flower`**, reagent tag `botania:seed_apothecary_reagent`

This revives the idea from the earlier #219 (closed as inactive) and folds in the review feedback you left there:
- reagent is a **tag** (`seed_apothecary_reagent` = wheat/beetroot/melon/pumpkin seeds + `#forge:seeds`), not a single item
- colors are inline, no global variable
- output id is inline, no intermediate variable
- petals also use the `botania:petals/<color>` tags

## Balance
4 petals per double flower. A double flower is worth ~2 single flowers, so even if a flower->petal recipe is ever added the ratio stays non-exploitable (no infinite petals). Verified there is currently no recipe or loot path converting double flowers back into petals.

## Testing
- Verified the 16 `*_double_flower` ids, the 16 `botania:petals/<color>` tags, and the reagent tag contents against the Botania jar and pack data.
- Manual in-game check (no CI in the repo): Petal Apothecary + reagent + 4 petals of a color -> matching double flower.

## Notes
- Targets `4.1.0`.