### PR TITLE
Fix issues with Jade Crop Info

### DIFF
--- a/kubejs/assets/society/lang/ko_kr.json
+++ b/kubejs/assets/society/lang/ko_kr.json
@@ -519,7 +519,7 @@
   "jei.society.tea_drying": "블록을 설치하고 기다리기...",
   "jade.society.working_block_entity.progress": "진행도: %s/%s ",
   "jade.society.crop_growth":"성장: %s/%s 일",
-  "jade.society.crop_growth.mature":"수확 가능",
+  "jade.society.crop_growth.mature":"성체",
   "jade.society.crop_growth.stop":"생장 정지됨",
   "jade.society.crop_growth.need_stem":"포도 지지대 필요",
   "jade.society.crop_growth.need_lattice":"포도 격자판 필요",

--- a/kubejs/client_scripts/jadeClient.js
+++ b/kubejs/client_scripts/jadeClient.js
@@ -189,7 +189,8 @@ global["JadeSocietyCropClientCallback"] = (
     "farmersdelight:rice_panicles"
   ].includes(name));
   const fertilizerNotApplies = [
-    "farmersdelight:rice_panicles"
+    "farmersdelight:rice_panicles",
+    "minecraft:sweet_berry_bush"
   ];
   const grapeMap = {
     red: "vinery:red_grape_seeds",
@@ -258,7 +259,21 @@ global["JadeSocietyCropClientCallback"] = (
     }
   };
 
-  if ($SereneFertility.isCrop(state) && blockContainer.hasTag("dew_drop_farmland_growth:cancel_random_tick")) {
+  if (name.includes("grapevine_stem") || name.match(/vinery:.+_lattice/i)) {
+    var grape_age = state.getValue(BlockProperties.AGE_4);  
+    if (grape_age == 0) return;
+    addGrowthLevelTooltip(
+      grape_age,
+      4,
+      isCropFertile(grapeMap[state.getValue(block.getStateDefinition().getProperty("grape")).getSerializedName()])
+    );
+  } else if (name.includes("grape_bush")) {
+    var bush_age = state.getValue(BlockProperties.AGE_3);
+    addGrowthLevelTooltip(bush_age, 3, isCropFertile(grapeMap[name.replace("_grape_bush", "")]));
+    tooltip.add(Component.translatable("jade.society.crop_growth.stop").red());
+    if (name.includes("jungle")) tooltip.add(Component.translatable("jade.society.crop_growth.need_lattice").red());
+    else tooltip.add(Component.translatable("jade.society.crop_growth.need_stem").red());
+  } else if ($SereneFertility.isCrop(state) && blockContainer.hasTag("dew_drop_farmland_growth:cancel_random_tick")) {
     try {
       if (block instanceof $CropBlock) {
         addGrowthLevelTooltip(block.getAge(state), block.getMaxAge(), isCropFertile(name));
@@ -272,20 +287,6 @@ global["JadeSocietyCropClientCallback"] = (
         addGrowthLevelTooltip(state.getValue(BlockProperties.AGE_3), 3, isCropFertile(name));
       } 
     } catch (e) {}
-  } else if (name.includes("grape_bush")) {
-    const age = state.getValue(BlockProperties.AGE_3);
-    addGrowthLevelTooltip(age, 3, isCropFertile(grapeMap[name.replace("_grape_bush", "")]));
-    tooltip.add(Component.translatable("jade.society.crop_growth.stop").red());
-    if (name.includes("jungle")) tooltip.add(Component.translatable("jade.society.crop_growth.need_lattice").red());
-    else tooltip.add(Component.translatable("jade.society.crop_growth.need_stem").red());
-  } else if (name.includes("grapevine_stem") || name.match(/vinery:.+_lattice/i)) {
-    const age = state.getValue(BlockProperties.AGE_4);
-    if (age == 0) return;
-    addGrowthLevelTooltip(
-      age,
-      4,
-      isCropFertile(grapeMap[state.getValue(block.getStateDefinition().getProperty("grape")).getSerializedName()])
-    );
   } else {
     $JadeCropInfo.INSTANCE.appendTooltip(tooltip.getTooltip(), accessor, pluginConfig);
     if (!blockContainer.hasTag("dew_drop_farmland_growth:cancel_random_tick") && $SereneFertility.isCrop(state) && !isCropFertile(name)) {

--- a/kubejs/client_scripts/jadeClient.js
+++ b/kubejs/client_scripts/jadeClient.js
@@ -190,7 +190,9 @@ global["JadeSocietyCropClientCallback"] = (
   ].includes(name));
   const fertilizerNotApplies = [
     "farmersdelight:rice_panicles",
-    "minecraft:sweet_berry_bush"
+    "minecraft:sweet_berry_bush",
+    "windswept:wild_berry_bush",
+    "vintagedelight:gearo_berry_bush"
   ];
   const grapeMap = {
     red: "vinery:red_grape_seeds",
@@ -287,6 +289,8 @@ global["JadeSocietyCropClientCallback"] = (
         addGrowthLevelTooltip(state.getValue(BlockProperties.AGE_3), 3, isCropFertile(name));
       } 
     } catch (e) {}
+  } else if("minecraft:torchflower".equals(name)) {
+    tooltip.add(Component.translatable("jade.society.crop_growth.mature").darkGreen());
   } else {
     $JadeCropInfo.INSTANCE.appendTooltip(tooltip.getTooltip(), accessor, pluginConfig);
     if (!blockContainer.hasTag("dew_drop_farmland_growth:cancel_random_tick") && $SereneFertility.isCrop(state) && !isCropFertile(name)) {


### PR DESCRIPTION
## Pull Request name
Fix serveral issues with Jade Crop growth counter
## PR checklist
Check all that apply
- [x] I have read the [contribution guide](https://github.com/Chakyl/society-sunlit-valley?tab=readme-ov-file#contribution-guide)
- [x] Bugfix, typos, documentation
- [ ] New content
- [x] Changes to existing content
- [ ] Translation
- [ ] Work in this PR contains AI generated text, images, or code
## Changelog
- Fixed grape stem/lattice doesn't show counter
- Fixed issue where growth fertilizer does not apply to Berry bushes, but appears to do so
- Mature torchflower now display `Mature` in Jade
