### PR TITLE
Fixes coin leaderboard destroying high pop servers

### DIFF
--- a/config/fancymenu/assets/changelog_en_us.markdown
+++ b/config/fancymenu/assets/changelog_en_us.markdown
@@ -8,6 +8,8 @@
 - Added Lemon Beignets
 - Added Suspicious Milk Tea
 - Added Ancient Builders Tool artifact
+- Added Overflow token support for shared accounts
+- Added double-sided text for coin leaderboard
 - Changed Earth Crystal trader trade from rice to cotton
 - Changed Jade trader trade from Aegis Wine to dried Lemon 
 - Increased height of coin leaderboard by 1/4th of a block to make it less smudged
@@ -18,6 +20,7 @@
 - Fixed issues with the Sakura building set
 - Fixed Smallmouth Bass not being catchable at night in Autumn
 - Fixed EMI not being searchable by blocktag by downgrading version
+- Optimized coin leaderboard
 
 ## 4.0.0
 - Added Cozy Cafe, a new mod made for the pack that adds a Diner Dash/Plate Up! style cafe management minigame

--- a/config/fancymenu/assets/changelog_en_us.markdown
+++ b/config/fancymenu/assets/changelog_en_us.markdown
@@ -3,13 +3,12 @@
 ### v4.1.3
 ^^^
 --- 
+- Added Overflow token support for shared accounts (Re-equip your bank card to update)
 - Added Pineconetown villager home set by beawitched
 - Added Deep-a-Mochi
 - Added Lemon Beignets
 - Added Suspicious Milk Tea
 - Added Ancient Builders Tool artifact
-- Added Overflow token support for shared accounts
-- Added double-sided text for coin leaderboard
 - Changed Earth Crystal trader trade from rice to cotton
 - Changed Jade trader trade from Aegis Wine to dried Lemon 
 - Increased height of coin leaderboard by 1/4th of a block to make it less smudged

--- a/kubejs/server_scripts/serverEvents/updateCoinLeaderboard.js
+++ b/kubejs/server_scripts/serverEvents/updateCoinLeaderboard.js
@@ -53,7 +53,7 @@ const getTop10Coins = (server) => {
   return top10;
 };
 
-let tick = 0;
+let tick = 600;
 ServerEvents.tick(event => {
   tick++
   if (tick < 600) return;

--- a/kubejs/server_scripts/serverEvents/updateCoinLeaderboard.js
+++ b/kubejs/server_scripts/serverEvents/updateCoinLeaderboard.js
@@ -1,0 +1,62 @@
+console.info("[SOCIETY] updateCoinLeaderboard.js loaded");
+
+const getTeamName = (server, uuid) => {
+  let cardsList = server.persistentData.cardsList ?? {};
+  let playerList = server.persistentData.playerList ?? {};
+  if (playerList[uuid]) return playerList[uuid];
+  // let bankAccount = global.GLOBAL_BANK.getAccount(String(uuid));
+  // if (bankAccount && bankAccount.label !== "Blaze Banker") return bankAccount.label;
+  return playerList[cardsList[uuid][0]] + "'s Team";
+}
+
+const getTop10Coins = (server) => {
+  let playerList = server.persistentData.playerList;
+  let cardsList = server.persistentData.cardsList;
+  let overflowList = server.persistentData.overflowList;
+  if (!playerList) return undefined;
+  if (!cardsList) {
+    server.persistentData.cardsList = {};
+    cardsList = server.persistentData.cardsList;
+  }
+  let leaderboardMap = new Map();
+  global.GLOBAL_BANK.accounts.forEach((playerUUID, bankAccount) => {
+    let accUUID = String(playerUUID);
+    let cBankId = cardsList[accUUID];
+    let bankBalance = bankAccount.getBalance();
+
+    if (!playerList[playerUUID]) { // blaze banker, ignore
+      return;
+    } else if (cBankId != null && cBankId != playerUUID) {
+      bankAccount = global.GLOBAL_BANK.getAccount(cBankId);
+      accUUID = String(bankAccount.id);
+      if (!leaderboardMap.has(accUUID)) bankBalance += bankAccount.getBalance();
+    }
+
+    if (overflowList != null && overflowList[playerUUID] != null) {
+      bankBalance += overflowList[playerUUID] * 1006632960;
+    }
+
+    if (leaderboardMap.has(accUUID)) {
+      leaderboardMap.set(accUUID, leaderboardMap.get(accUUID) + bankBalance);
+    } else {
+      leaderboardMap.set(accUUID, bankBalance);
+    };
+  });
+  let top10Unammed = Array.from(leaderboardMap)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10);
+  let top10 = new Array()
+  for (let lbEntry of top10Unammed) {
+    let lbData = lbEntry.toString().split(`,`);
+    top10.push([getTeamName(server, lbData[0]), lbData[1]])
+  };
+  return top10;
+};
+
+let tick = 0;
+ServerEvents.tick(event => {
+  tick++
+  if (tick < 600) return;
+  tick = 0;
+  global.leaderboard = getTop10Coins(event.server);
+})

--- a/kubejs/server_scripts/tags/handleItemBlockFluidTags.js
+++ b/kubejs/server_scripts/tags/handleItemBlockFluidTags.js
@@ -796,7 +796,8 @@ ServerEvents.tags("block", (e) => {
     "society_trading:auto_trader",
     "society:fish_pond_manager",
     "society:fish_pond_hatchery",
-    "society:caterpillar_box"
+    "society:caterpillar_box",
+    "society:growth_obelisk_upper"
   ].forEach((block) => {
     immovableTags.forEach((tag) => {
       e.add(tag, block);

--- a/kubejs/startup_scripts/customMachines/coinLeaderboard.js
+++ b/kubejs/startup_scripts/customMachines/coinLeaderboard.js
@@ -1,86 +1,22 @@
 console.info("[SOCIETY] coinLeaderboard.js loaded");
 
-const updateLeaderboardMap = (server) => {
-  if (global.coinLBCooldown && global.coinLBCooldown > server.getTickCount()) {
-    return global.lastCoinLB;
-  }
-  global.coinLBCooldown = server.getTickCount() + 590;
-  let playerList = server.persistentData.playerList;
-  let cardsList = server.persistentData.cardsList;
-  let overflowList = server.persistentData.overflowList;
-  if (!playerList) return undefined;
-  if (!cardsList) {
-    server.persistentData.cardsList = {};
-    cardsList = server.persistentData.cardsList;
-  }
-  let leaderboardMap = new Map();
-  global.GLOBAL_BANK.accounts.forEach((playerUUID, bankAccount) => {
-    let accUUID = playerList[playerUUID];
-    let cBankId = cardsList[playerUUID];
-    let bankBalance = bankAccount.getBalance();
-
-    if (!accUUID) { // blaze banker
-      accUUID = String(bankAccount.id);
-    } else if (cBankId != null && cBankId != playerUUID) {
-      bankAccount = global.GLOBAL_BANK.getAccount(cBankId);
-      accUUID = String(bankAccount.id);
-    }
-
-    if (overflowList != null && overflowList[playerUUID] != null) {
-      bankBalance += overflowList[playerUUID] * 1006632960;
-    }
-
-    if (leaderboardMap.has(accUUID)) {
-      leaderboardMap.set(accUUID, leaderboardMap.get(accUUID) + bankBalance);
-    } else {
-      leaderboardMap.set(accUUID, bankBalance);
-    };
-  });
-  global.lastCoinLB = Array.from(leaderboardMap)
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 10);
-  return global.lastCoinLB;
-};
-
 global.updateLeaderboard = (block, level, server) => {
   let calcY = block.y + 3.25;
-  let leaderboardMap = updateLeaderboardMap(server);
-  let playerList = server.persistentData.playerList;
+  let leaderboardMap = global.leaderboard;
   if (!leaderboardMap) return;
   if (global.susFunctionLogging)
     console.log("[SOCIETY-SUSFN] coinLeaderboard.js");
   global.clearOldTextDisplay(block, level, "leaderboard");
-  if (!global.bankerNames) global.bankerNames = {};
 
   const displayText = Text.translatable("block.society.coin_leaderboard.title")
   global.spawnTextDisplay(block, calcY, "leaderboard", displayText);
-  // global.spawnTextDisplay(block, calcY, "leaderboard", displayText, 180);
   leaderboardMap.forEach((playerName) => {
     const balanceStr = playerName.toString().split(`,`);
-    const uuid = balanceStr[0]
-    if (uuid.length <= 1) return;
-    let accountName = uuid;
-    let bankAccount = global.GLOBAL_BANK.getAccount(uuid);
-    if (bankAccount) {
-      //accountName = bankAccount.label
-      //if (accountName == "Blaze Banker") { // default name
-        accountName = global.bankerNames[uuid];
-        if (!accountName) {
-          accountName = "";
-          for (const [playerUUID, name] of Object.entries(playerList)) {
-            if (bankAccount.isAuthorized(playerUUID)) {
-              accountName = `${name}'s Team`;
-              global.bankerNames[uuid] = accountName;
-              break;
-            };
-          };
-        };
-      //}
-    }
+    const lbName = balanceStr[0]
+    if (lbName.length <= 1) return;
     calcY -= 0.3;
-    const displayText = Text.of(`§6${accountName} §7- §f● §6${global.formatPrice(balanceStr[1])}`);
+    const displayText = Text.of(`§6${lbName} §7- §f● §6${global.formatPrice(balanceStr[1])}`);
     global.spawnTextDisplay(block, calcY, "leaderboard", displayText);
-    // global.spawnTextDisplay(block, calcY, "leaderboard", displayText, 180);
   });
 };
 

--- a/kubejs/startup_scripts/customMachines/coinLeaderboard.js
+++ b/kubejs/startup_scripts/customMachines/coinLeaderboard.js
@@ -2,7 +2,7 @@ console.info("[SOCIETY] coinLeaderboard.js loaded");
 
 global.updateLeaderboard = (block, level, server) => {
   let calcY = block.y + 3.25;
-  let leaderboardMap = global.leaderboard;
+  let leaderboardMap = global.leaderboard || [];
   if (!leaderboardMap) return;
   if (global.susFunctionLogging)
     console.log("[SOCIETY-SUSFN] coinLeaderboard.js");

--- a/kubejs/startup_scripts/customMachines/coinLeaderboard.js
+++ b/kubejs/startup_scripts/customMachines/coinLeaderboard.js
@@ -50,6 +50,7 @@ global.updateLeaderboard = (block, level, server) => {
   if (global.susFunctionLogging)
     console.log("[SOCIETY-SUSFN] coinLeaderboard.js");
   global.clearOldTextDisplay(block, level, "leaderboard");
+  if (!global.bankerNames) global.bankerNames = {};
 
   const displayText = Text.translatable("block.society.coin_leaderboard.title")
   global.spawnTextDisplay(block, calcY, "leaderboard", displayText);
@@ -63,11 +64,15 @@ global.updateLeaderboard = (block, level, server) => {
     if (bankAccount) {
       //accountName = bankAccount.label
       //if (accountName == "Blaze Banker") { // default name
-        accountName = "";
-        for (const [uuid, name] of Object.entries(playerList)) {
-          if (bankAccount.isAuthorized(uuid)) {
-            accountName = `${name}'s Team`;
-            break;
+        accountName = global.bankerNames[uuid];
+        if (!accountName) {
+          accountName = "";
+          for (const [playerUUID, name] of Object.entries(playerList)) {
+            if (bankAccount.isAuthorized(playerUUID)) {
+              accountName = `${name}'s Team`;
+              global.bankerNames[uuid] = accountName;
+              break;
+            };
           };
         };
       //}

--- a/kubejs/startup_scripts/customMachines/coinLeaderboard.js
+++ b/kubejs/startup_scripts/customMachines/coinLeaderboard.js
@@ -54,7 +54,7 @@ global.updateLeaderboard = (block, level, server) => {
 
   const displayText = Text.translatable("block.society.coin_leaderboard.title")
   global.spawnTextDisplay(block, calcY, "leaderboard", displayText);
-  global.spawnTextDisplay(block, calcY, "leaderboard", displayText, 180);
+  // global.spawnTextDisplay(block, calcY, "leaderboard", displayText, 180);
   leaderboardMap.forEach((playerName) => {
     const balanceStr = playerName.toString().split(`,`);
     const uuid = balanceStr[0]
@@ -80,7 +80,7 @@ global.updateLeaderboard = (block, level, server) => {
     calcY -= 0.3;
     const displayText = Text.of(`§6${accountName} §7- §f● §6${global.formatPrice(balanceStr[1])}`);
     global.spawnTextDisplay(block, calcY, "leaderboard", displayText);
-    global.spawnTextDisplay(block, calcY, "leaderboard", displayText, 180);
+    // global.spawnTextDisplay(block, calcY, "leaderboard", displayText, 180);
   });
 };
 

--- a/kubejs/startup_scripts/customMachines/coinLeaderboard.js
+++ b/kubejs/startup_scripts/customMachines/coinLeaderboard.js
@@ -1,59 +1,81 @@
 console.info("[SOCIETY] coinLeaderboard.js loaded");
 
 const updateLeaderboardMap = (server) => {
-  let accountName;
+  if (global.coinLBCooldown && global.coinLBCooldown > server.getTickCount()) {
+    return global.lastCoinLB;
+  }
+  global.coinLBCooldown = server.getTickCount() + 590;
   let playerList = server.persistentData.playerList;
+  let cardsList = server.persistentData.cardsList;
   let overflowList = server.persistentData.overflowList;
   if (!playerList) return undefined;
+  if (!cardsList) {
+    server.persistentData.cardsList = {};
+    cardsList = server.persistentData.cardsList;
+  }
   let leaderboardMap = new Map();
   global.GLOBAL_BANK.accounts.forEach((playerUUID, bankAccount) => {
-    accountName = playerList[playerUUID];
-    if (overflowList != null && overflowList[playerUUID] != null) {
-      leaderboardMap.set(
-        accountName,
-        bankAccount.getBalance() + overflowList[playerUUID] * 1006632960
-      );
-    } else {
-      if (!accountName) {
-        accountName = "";
-        Object.keys(server.persistentData.playerList).forEach((playerUUID) => {
-          if (accountName == "" && bankAccount.isAuthorized(playerUUID)) {
-           accountName += playerList[playerUUID] + "'s Team"
-          }
-        })
-      }
-      leaderboardMap.set(accountName, bankAccount.getBalance());
+    let accUUID = playerList[playerUUID];
+    let cBankId = cardsList[playerUUID];
+    let bankBalance = bankAccount.getBalance();
+
+    if (!accUUID) { // blaze banker
+      accUUID = String(bankAccount.id);
+    } else if (cBankId != null && cBankId != playerUUID) {
+      bankAccount = global.GLOBAL_BANK.getAccount(cBankId);
+      accUUID = String(bankAccount.id);
     }
+
+    if (overflowList != null && overflowList[playerUUID] != null) {
+      bankBalance += overflowList[playerUUID] * 1006632960;
+    }
+
+    if (leaderboardMap.has(accUUID)) {
+      leaderboardMap.set(accUUID, leaderboardMap.get(accUUID) + bankBalance);
+    } else {
+      leaderboardMap.set(accUUID, bankBalance);
+    };
   });
-  return Array.from(leaderboardMap)
+  global.lastCoinLB = Array.from(leaderboardMap)
     .sort((a, b) => b[1] - a[1])
     .slice(0, 10);
+  return global.lastCoinLB;
 };
 
 global.updateLeaderboard = (block, level, server) => {
   let calcY = block.y + 3.25;
   let leaderboardMap = updateLeaderboardMap(server);
+  let playerList = server.persistentData.playerList;
   if (!leaderboardMap) return;
   if (global.susFunctionLogging)
     console.log("[SOCIETY-SUSFN] coinLeaderboard.js");
   global.clearOldTextDisplay(block, level, "leaderboard");
 
-  global.spawnTextDisplay(
-    block,
-    calcY,
-    "leaderboard",
-    Text.translatable("block.society.coin_leaderboard.title")
-  );
+  const displayText = Text.translatable("block.society.coin_leaderboard.title")
+  global.spawnTextDisplay(block, calcY, "leaderboard", displayText);
+  global.spawnTextDisplay(block, calcY, "leaderboard", displayText, 180);
   leaderboardMap.forEach((playerName) => {
     const balanceStr = playerName.toString().split(`,`);
-    if (balanceStr[0].length <= 1) return;
+    const uuid = balanceStr[0]
+    if (uuid.length <= 1) return;
+    let accountName = uuid;
+    let bankAccount = global.GLOBAL_BANK.getAccount(uuid);
+    if (bankAccount) {
+      //accountName = bankAccount.label
+      //if (accountName == "Blaze Banker") { // default name
+        accountName = "";
+        for (const [uuid, name] of Object.entries(playerList)) {
+          if (bankAccount.isAuthorized(uuid)) {
+            accountName = `${name}'s Team`;
+            break;
+          };
+        };
+      //}
+    }
     calcY -= 0.3;
-    global.spawnTextDisplay(
-      block,
-      calcY,
-      "leaderboard",
-      Text.of(`§6${balanceStr[0]} §7- §f● §6${balanceStr[1].replace(/\B(?=(\d{3})+(?!\d))/g, ",")}`)
-    );
+    const displayText = Text.of(`§6${accountName} §7- §f● §6${global.formatPrice(balanceStr[1])}`);
+    global.spawnTextDisplay(block, calcY, "leaderboard", displayText);
+    global.spawnTextDisplay(block, calcY, "leaderboard", displayText, 180);
   });
 };
 

--- a/kubejs/startup_scripts/forgeEvents/coinLeaderboard.js
+++ b/kubejs/startup_scripts/forgeEvents/coinLeaderboard.js
@@ -1,0 +1,16 @@
+ForgeEvents.onEvent("top.theillusivec4.curios.api.event.CurioChangeEvent", e => {
+    const {entity} = e;
+    if (!(entity.isPlayer())) return;
+    const slot = e.getIdentifier();
+    if (slot !== 'card') return;
+    let bankAccountId = global.getCardCurio(entity);
+    const server = entity.getServer();
+    let cardsList = server.persistentData.cardsList ?? {};
+    let playerList = server.persistentData.playerList;
+    if (bankAccountId == null | playerList[entity.uuid]) {
+        cardsList[entity.uuid] = null;
+    } else {
+        cardsList[entity.uuid] = String(bankAccountId);
+    };
+    server.persistentData.cardsList = cardsList;
+});

--- a/kubejs/startup_scripts/forgeEvents/coinLeaderboard.js
+++ b/kubejs/startup_scripts/forgeEvents/coinLeaderboard.js
@@ -5,12 +5,19 @@ ForgeEvents.onEvent("top.theillusivec4.curios.api.event.CurioChangeEvent", e => 
     if (slot !== 'card') return;
     let bankAccountId = global.getCardCurio(entity);
     const server = entity.getServer();
+    const uuid = String(entity.uuid);
     let cardsList = server.persistentData.cardsList ?? {};
     let playerList = server.persistentData.playerList;
-    if (bankAccountId == null | playerList[entity.uuid]) {
-        cardsList[entity.uuid] = null;
+    let prevAccId = cardsList[uuid];
+    if (!playerList[prevAccId] && prevAccId && cardsList[prevAccId]) {
+        cardsList[prevAccId].filter(iUUID => iUUID !== uuid);
+    };
+    if (bankAccountId == null || playerList[bankAccountId]) {
+        delete cardsList[uuid];
     } else {
-        cardsList[entity.uuid] = String(bankAccountId);
+        cardsList[uuid] = String(bankAccountId);
+        cardsList[String(bankAccountId)] = cardsList[String(bankAccountId)] ?? [];
+        cardsList[String(bankAccountId)].push(uuid);
     };
     server.persistentData.cardsList = cardsList;
 });

--- a/kubejs/startup_scripts/globalBlockEntityHandlers.js
+++ b/kubejs/startup_scripts/globalBlockEntityHandlers.js
@@ -868,7 +868,8 @@ global.rotationFromFacing = (facing) => {
   }
 };
 
-global.spawnTextDisplay = (block, y, id, text) => {
+global.spawnTextDisplay = (block, y, id, text, rotation) => {
+  rotation = rotation ?? 0
   let entity;
   const { x, z } = block;
   entity = block.createEntity("minecraft:text_display");
@@ -876,7 +877,7 @@ global.spawnTextDisplay = (block, y, id, text) => {
   newNbt.text = `${text.toJson()}`;
   newNbt.background = 0;
   newNbt.Rotation = [
-    NBT.f(global.rotationFromFacing(block.properties.get("facing"))),
+    NBT.f(global.rotationFromFacing(block.properties.get("facing")) + rotation),
     NBT.f(0),
   ];
   entity.setNbt(newNbt);

--- a/kubejs/startup_scripts/globalRegistry.js
+++ b/kubejs/startup_scripts/globalRegistry.js
@@ -3,6 +3,7 @@ const NUMISMATICS = Java.loadClass("dev.ithundxr.createnumismatics.Numismatics")
 const NUMISMATICS_CURIO_UTILS = Java.loadClass("io.github.chakyl.numismaticsutils.utils.CurioUtils");
 
 global.GLOBAL_BANK = NUMISMATICS.BANK;
+global.getCardCurio = NUMISMATICS_CURIO_UTILS.getCardCurio;
 global.getPersonalOrCurioAccount = NUMISMATICS_CURIO_UTILS.getPersonalOrCurioAccount;
 global.depositIntoPersonalOrCurio = NUMISMATICS_CURIO_UTILS.depositIntoPersonalOrCurio;
 global.deductFromPersonalOrCurio = NUMISMATICS_CURIO_UTILS.deductFromPersonalOrCurio;


### PR DESCRIPTION
## Coin leaderboard optimizations + additions
Stops the coin leaderboard nuking servers that have had hundreds if not thousands of players who've joined
## PR checklist
Check all that apply
- [x] I have read the [contribution guide](https://github.com/Chakyl/society-sunlit-valley?tab=readme-ov-file#contribution-guide)
- [x] Bugfix, typos, documentation
- [ ] New content
- [x] Changes to existing content
- [ ] Translation
- [ ] Work in this PR contains AI generated text, images, or code
## Changelog
- Adds overflow token support for shared bank accounts (blaze bankers)
- Optimizes blaze banker name fetching
- Adds support for rotating text displays (for double-sided text)
- Adds global cooldown to coin leaderboards (to not have every coin lb reconstruct the list every 30s)