### PR TITLE
Coin Leaderboard bug-fixes and optimizations

### DIFF
--- a/config/fancymenu/assets/changelog_en_us.markdown
+++ b/config/fancymenu/assets/changelog_en_us.markdown
@@ -2,6 +2,7 @@
 ## Cozy Cafe
 ### v4.1.5
 ^^^
+- Fixed coin leaderboard edge-cases
 --- 
 
 TODO 

--- a/kubejs/server_scripts/serverEvents/updateCoinLeaderboard.js
+++ b/kubejs/server_scripts/serverEvents/updateCoinLeaderboard.js
@@ -116,6 +116,6 @@ const updateLeaderboardRanking = (server) => {
 if (global.lbServer) global.leaderboard = getLeaderboardRanking(global.lbServer);
 ServerEvents.loaded(e => { global.leaderboard = getLeaderboardRanking(e.server); global.lbServer = e.server; });
 ServerEvents.tick((e) => {
-  if (e.server.getTickCount() % 50) return;
+  if (e.server.getTickCount() % 600) return;
   global.leaderboard = updateLeaderboardRanking(e.server);
 });

--- a/kubejs/server_scripts/serverEvents/updateCoinLeaderboard.js
+++ b/kubejs/server_scripts/serverEvents/updateCoinLeaderboard.js
@@ -1,55 +1,121 @@
 console.info("[SOCIETY] updateCoinLeaderboard.js loaded");
 
+global.visibleRankings = global.visibleRankings ?? new Set();
+let players;
+
+const trim = (str) => {
+  return String(str).replace(/^"|"$/g, '');
+};
+
 const getTeamName = (server, uuid) => {
-  let cardsList = server.persistentData.cardsList ?? {};
   let playerList = server.persistentData.playerList ?? {};
   if (playerList[uuid]) return playerList[uuid];
+  let cardsList = server.persistentData.cardsList ?? {};
   return playerList[cardsList[uuid][0]] + "'s Team";
-}
+};
+
+const handleAccount = (leaderboard, cardID, overflowTokens, accountUUID, bankAccount) => {
+  let bankBalance = bankAccount.getBalance();
+  if (cardID != null) {
+    bankAccount = global.GLOBAL_BANK.getAccount(cardID);
+    if (bankAccount != null) {
+      accountUUID = String(bankAccount.id);
+      if (!leaderboard.has(accountUUID)) bankBalance += bankAccount.getBalance();
+    };
+  };
+
+  if (overflowTokens != null) bankBalance += overflowTokens * 1006632960;
+
+  if (leaderboard.has(accountUUID)) {
+    leaderboard.set(accountUUID, leaderboard.get(accountUUID) + bankBalance);
+  } else {
+    leaderboard.set(accountUUID, bankBalance);
+  };
+};
 
 const getLeaderboardRanking = (server) => {
+  players = new Set();
+  server.players.forEach(player => players.add(String(player.uuid)));
   let playerList = server.persistentData.playerList;
   let cardsList = server.persistentData.cardsList;
-  let overflowList = server.persistentData.overflowList;
-  if (!playerList) return undefined;
+  let overflowList = server.persistentData.overflowList || [];
+  if (!playerList) return [];
   if (!cardsList) {
     server.persistentData.cardsList = {};
     cardsList = server.persistentData.cardsList;
-  }
+  };
   let leaderboardMap = new Map();
   global.GLOBAL_BANK.accounts.forEach((playerUUID, bankAccount) => {
+    if (!playerList[playerUUID]) return; // blaze banker, ignore
     let accountUUID = String(playerUUID);
     let cardID = cardsList[accountUUID];
-    let bankBalance = bankAccount.getBalance();
-
-    if (!playerList[playerUUID]) { // blaze banker, ignore
-      return;
-    } else if (cardID != null && cardID != playerUUID) {
-      bankAccount = global.GLOBAL_BANK.getAccount(cardID);
-      accountUUID = String(bankAccount.id);
-      if (!leaderboardMap.has(accountUUID)) bankBalance += bankAccount.getBalance();
-    }
-    if (overflowList != null && overflowList[playerUUID] != null) {
-      bankBalance += overflowList[playerUUID] * 1006632960;
-    }
-    if (leaderboardMap.has(accountUUID)) {
-      leaderboardMap.set(accountUUID, leaderboardMap.get(accountUUID) + bankBalance);
-    } else {
-      leaderboardMap.set(accountUUID, bankBalance);
-    };
+    handleAccount(leaderboardMap, cardID, overflowList[playerUUID], accountUUID, bankAccount);
   });
-  let rankingUnammed = Array.from(leaderboardMap)
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 10);
-  let ranking = new Array()
-  for (let entry of rankingUnammed) {
-    let entryData = entry.toString().split(",");
-    ranking.push([getTeamName(server, entryData[0]), entryData[1]])
+  let sortedRankings = Array.from(leaderboardMap)
+    .sort((a, b) => b[1] - a[1]);
+  let i = 0;
+  for (let entryData of sortedRankings) {
+    let accountUUID = entryData[0];
+    if (players.has(accountUUID)) continue;
+    if (Array.isArray(cardsList[accountUUID]) && cardsList[accountUUID].some(player => players.has(trim(player)))) continue;
+    if (i++ >= 30) break;
+    global.visibleRankings.add(accountUUID);
+  };
+  let rankingUnamed = sortedRankings.slice(0, 10);
+  let ranking = new Array();
+  for (let entryData of rankingUnamed) {
+    ranking.push([getTeamName(server, entryData[0]), entryData[1]]);
+    global.visibleRankings.add(entryData[0]);
   };
   return ranking;
 };
 
+const updateLeaderboardRanking = (server) => {
+  if (!server.persistentData.playerList) return [];
+  let playerList = server.persistentData.playerList;
+  let prevPlayers = players;
+  players = new Set();
+  server.players.forEach(player => players.add(String(player.uuid)));
+  let cardsList = server.persistentData.cardsList;
+  let overflowList = server.persistentData.overflowList || {};
+  let leaderboardMap = new Map();
+  let iteratedPlayers = new Set();
+  for (let accountUUID of global.visibleRankings) { // add top 10 & teams that were on it
+    let accounts = [accountUUID];
+    let cardID = cardsList[accountUUID];
+    if (cardID) {
+      if (Array.isArray(cardID)) { accounts = cardID; cardID = accountUUID; } else accounts = cardsList[cardID];
+      let sharedBank = global.GLOBAL_BANK.getAccount(cardID);
+      if (!sharedBank) { delete cardsList[accountUUID]; continue; }; // banker was broken
+    } else if (!playerList[accountUUID]) continue;
+    for (let accountUUID of accounts) {
+      let trimmedAccountUUID = trim(accountUUID);
+      if (iteratedPlayers.has(trimmedAccountUUID)) continue;
+      let bankAccount = global.GLOBAL_BANK.getAccount(trimmedAccountUUID);
+      handleAccount(leaderboardMap, cardID, overflowList[trimmedAccountUUID], accountUUID, bankAccount);
+      iteratedPlayers.add(trimmedAccountUUID);
+    };
+  };
+  prevPlayers.forEach(accountUUID => {
+    if (iteratedPlayers.has(accountUUID)) return;
+    let cardID = cardsList[accountUUID];
+    let bankAccount = global.GLOBAL_BANK.getAccount(accountUUID);
+    handleAccount(leaderboardMap, cardID, overflowList[accountUUID], accountUUID, bankAccount);
+  });
+  let rankingUnamed = Array.from(leaderboardMap)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10);
+  let ranking = new Array();
+  for (let entryData  of rankingUnamed) {
+    ranking.push([getTeamName(server, entryData[0]), entryData[1]]);
+    global.visibleRankings.add(entryData[0]);
+  };
+  return ranking;
+};
+
+if (global.lbServer) global.leaderboard = getLeaderboardRanking(global.lbServer);
+ServerEvents.loaded(e => { global.leaderboard = getLeaderboardRanking(e.server); global.lbServer = e.server; });
 ServerEvents.tick((e) => {
-  if (e.server.getTickCount() % 600) return;
-  global.leaderboard = getLeaderboardRanking(e.server);
-})
+  if (e.server.getTickCount() % 50) return;
+  global.leaderboard = updateLeaderboardRanking(e.server);
+});

--- a/kubejs/server_scripts/serverEvents/updateCoinLeaderboard.js
+++ b/kubejs/server_scripts/serverEvents/updateCoinLeaderboard.js
@@ -38,7 +38,7 @@ const getLeaderboardRanking = (server) => {
   server.players.forEach(player => players.add(String(player.uuid)));
   let playerList = server.persistentData.playerList;
   let cardsList = server.persistentData.cardsList;
-  let overflowList = server.persistentData.overflowList || [];
+  let overflowList = server.persistentData.overflowList ?? {};
   if (!playerList) return [];
   if (!cardsList) {
     server.persistentData.cardsList = {};
@@ -77,7 +77,7 @@ const updateLeaderboardRanking = (server) => {
   players = new Set();
   server.players.forEach(player => players.add(String(player.uuid)));
   let cardsList = server.persistentData.cardsList;
-  let overflowList = server.persistentData.overflowList || {};
+  let overflowList = server.persistentData.overflowList ?? {};
   let leaderboardMap = new Map();
   let iteratedPlayers = new Set();
   for (let accountUUID of global.visibleRankings) { // add top 10 & teams that were on it

--- a/kubejs/startup_scripts/forgeEvents/equipBankCard.js
+++ b/kubejs/startup_scripts/forgeEvents/equipBankCard.js
@@ -1,25 +1,30 @@
 console.info("[SOCIETY] equipBankCard.js loaded");
 
 ForgeEvents.onEvent("top.theillusivec4.curios.api.event.CurioChangeEvent", (e) => {
-    const { entity } = e;
-    if (!(entity.isPlayer())) return;
-    const slot = e.getIdentifier();
-    if (slot !== 'card') return;
-    let bankAccountId = global.getCardCurio(entity);
-    const server = entity.getServer();
-    const uuid = String(entity.uuid);
-    let cardsList = server.persistentData.cardsList ?? {};
-    let playerList = server.persistentData.playerList ?? {};
-    let prevAccId = cardsList[uuid];
-    if (!playerList[prevAccId] && prevAccId && cardsList[prevAccId]) {
-        cardsList[prevAccId].filter(iUUID => iUUID !== uuid);
+  const { entity } = e;
+  if (!(entity.isPlayer())) return;
+  const slot = e.getIdentifier();
+  if (slot !== 'card') return;
+  let bankAccountId = global.getCardCurio(entity);
+  const server = entity.getServer();
+  let playerUUID = String(entity.uuid);
+  let cardsList = server.persistentData.cardsList ?? {};
+  let playerList = server.persistentData.playerList ?? {};
+  let prevAccId = cardsList[playerUUID];
+  if (prevAccId) {
+    if (prevAccId == bankAccountId) return;
+    if (!playerList[prevAccId] && cardsList[prevAccId]) {
+      cardsList[prevAccId] = cardsList[prevAccId].filter(iUUID => iUUID !== playerUUID);
+      if (!cardsList[prevAccId].length) delete cardsList[prevAccId];
     };
-    if (bankAccountId == null || playerList[bankAccountId]) {
-        delete cardsList[uuid];
-    } else {
-        cardsList[uuid] = String(bankAccountId);
-        cardsList[String(bankAccountId)] = cardsList[String(bankAccountId)] ?? [];
-        cardsList[String(bankAccountId)].push(uuid);
-    };
-    server.persistentData.cardsList = cardsList;
+  };
+  if (bankAccountId == null || playerList[bankAccountId]) {
+    delete cardsList[playerUUID];
+  } else {
+    let accountUUID = String(bankAccountId);
+    cardsList[playerUUID] = accountUUID;
+    cardsList[accountUUID] = cardsList[accountUUID] ?? [];
+    if (cardsList[accountUUID].indexOf(playerUUID) === -1) cardsList[accountUUID].push(playerUUID);
+  };
+  server.persistentData.cardsList = cardsList;
 });


### PR DESCRIPTION
## Coin Leaderboard bug-fixes and optimizations
- Optimizes the coin leaderboard
- Fixes equipping a card adding your UUID to the UUID list for that acc without checking if its there already
- Fixes un-equipping a card not removing your UUID from the UUID list and not deleting the shard acc from the card list if there are no other users using it
- Fixes broken blaze bankers breaking the coin leaderboard

It does have an extreme edge-case where if there's an offline top 11 player and somebody were to load their base
and they have shipping bins automatically selling stuff that would put them into the top 10, it wouldn't add them
but it'd be fine the moment they joined the server
## PR checklist
- [x] I have read the [contribution guide](https://github.com/Chakyl/society-sunlit-valley?tab=readme-ov-file#contribution-guide)
- [x] Bugfix, typos, documentation
- [x] Changes to existing content
## Changelog
- Fixes coin leaderboard edge-cases
